### PR TITLE
Fix LambdaPermission within the cloudformation template

### DIFF
--- a/cfn.template.yaml
+++ b/cfn.template.yaml
@@ -135,7 +135,7 @@ Resources:
       FunctionName: !GetAtt Lambda.Arn
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApi}/*
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApi}/*/*
 
 
 # firehose to write to a cross account s3 bucket. 


### PR DESCRIPTION
This fixes the `LambdaPermission` used by API Gateway to execute our lambda.

`/*` by itself seems to only refer to the stage without any reference to a method. `/*/*` refers to any Stage and any Method.