### PR TITLE
Create ALB to direct traffic to consent Lambda

### DIFF
--- a/cfn.template.yaml
+++ b/cfn.template.yaml
@@ -260,8 +260,6 @@ Resources:
   TargetGroupForLambda:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      Matcher: 
-        HttpCode: 200
       Name: !Sub 
         - ${Stack}-${App}-${Stage}
         - App:
@@ -310,3 +308,5 @@ Outputs:
     Value: !GetAtt Lambda.Arn
   TargetGroupArn:
     Value: !Ref TargetGroupForLambda
+  ALBDnsName:
+    Value: !GetAtt ConsentLoadBalancer.DNSName

--- a/cfn.template.yaml
+++ b/cfn.template.yaml
@@ -14,16 +14,10 @@ Parameters:
     Default: aws-frontend-artifacts
   FrontendVpcId:
     Description: Frontend VPC ID
-    Type: String
-  FrontendSubnetId1a:
-    Description: Frontend Subnet 1a
-    Type: String
-  FrontendSubnetId1b:
-    Description: Frontend Subnet 1b
-    Type: String
-  FrontendSubnetId1c:
-    Description: Frontend Subnet 1c
-    Type: String
+    Type: AWS::EC2::VPC::Id
+  FrontendSubnets:
+    Description: Frontend Subnets to launch ALB into
+    Type: List<AWS::EC2::Subnet::Id>
 
 Mappings:
   Constants:
@@ -256,10 +250,7 @@ Resources:
       Scheme: internet-facing
       SecurityGroups: 
         - !Ref AllowHttpSecurityGroup
-      Subnets: 
-        - !Ref FrontendSubnetId1a
-        - !Ref FrontendSubnetId1b
-        - !Ref FrontendSubnetId1c
+      Subnets: !Ref FrontendSubnets
       Tags: 
         - { Key: Stack, Value: !FindInMap [Constants, Stack, Value] }
         - { Key: App, Value: !FindInMap [Constants, App, Value] }

--- a/cfn.template.yaml
+++ b/cfn.template.yaml
@@ -12,6 +12,18 @@ Parameters:
     Description: S3 bucket holding the lambda code
     Type: String
     Default: aws-frontend-artifacts
+  FrontendVpcId:
+    Description: Frontend VPC ID
+    Type: String
+  FrontendSubnetId1a:
+    Description: Frontend Subnet 1a
+    Type: String
+  FrontendSubnetId1b:
+    Description: Frontend Subnet 1b
+    Type: String
+  FrontendSubnetId1c:
+    Description: Frontend Subnet 1c
+    Type: String
 
 Mappings:
   Constants:
@@ -218,3 +230,92 @@ Resources:
             - '*'
       Roles:
         - !Ref deliveryRole
+
+  # ALB Solution
+  LambdaPermissionForALB:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt Lambda.Arn
+      Action: lambda:InvokeFunction
+      Principal: elasticloadbalancing.amazonaws.com
+      SourceArn: !Ref TargetGroupForLambda
+
+  ConsentLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties: 
+      IpAddressType: ipv4
+      LoadBalancerAttributes:
+        - Key: idle_timeout.timeout_seconds
+          Value: 10
+      Name: !Sub 
+        - ${Stack}-${App}-${Stage}
+        - App:
+            !FindInMap [Constants, App, Value]
+          Stack:
+            !FindInMap [Constants, Stack, Value]
+      Scheme: internet-facing
+      SecurityGroups: 
+        - !Ref AllowHttpSecurityGroup
+      Subnets: 
+        - !Ref FrontendSubnetId1a
+        - !Ref FrontendSubnetId1b
+        - !Ref FrontendSubnetId1c
+      Tags: 
+        - { Key: Stack, Value: !FindInMap [Constants, Stack, Value] }
+        - { Key: App, Value: !FindInMap [Constants, App, Value] }
+        - { Key: Stage, Value: !Ref Stage }
+      Type: application
+
+  TargetGroupForLambda:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Matcher: 
+        HttpCode: 200
+      Name: !Sub 
+        - ${Stack}-${App}-${Stage}
+        - App:
+            !FindInMap [Constants, App, Value]
+          Stack:
+            !FindInMap [Constants, Stack, Value]
+      Tags: 
+        - { Key: Stack, Value: !FindInMap [Constants, Stack, Value] }
+        - { Key: App, Value: !FindInMap [Constants, App, Value] }
+        - { Key: Stage, Value: !Ref Stage }
+      TargetGroupAttributes: 
+        - Key: lambda.multi_value_headers.enabled
+          Value: false
+      TargetType: lambda
+      Targets:  # This can only contain one lambda target if the TargetType is lambda
+        - AvailabilityZone: all
+          Id: !GetAtt Lambda.Arn
+      UnhealthyThresholdCount: 2  # Default for lambda
+
+  ConsentListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties: 
+      DefaultActions: 
+        - TargetGroupArn: !Ref TargetGroupForLambda
+          Type: forward
+      LoadBalancerArn: !Ref ConsentLoadBalancer
+      Port: 80
+      Protocol: HTTP
+
+  AllowHttpSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allows HTTP and HTTPS inbound connections
+      VpcId: !Ref FrontendVpcId
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: '80'
+        ToPort: '80'
+        CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+      - IpProtocol: -1
+        CidrIp: 0.0.0.0/0
+
+Outputs:
+  LambdaArn:
+    Value: !GetAtt Lambda.Arn
+  TargetGroupArn:
+    Value: !Ref TargetGroupForLambda


### PR DESCRIPTION
This creates a new Application Load Balancer within the Frontend VPC using three of it's subnets.

Currently it listened on port 80 just for testing, however we want to move over to TLS as soon as possible but will need a new certifcate for a new domain for which will have a CNAME to the ALB domain.

There is a [idle timeout](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout) on the ALB of 10 seconds. The default for the lambda seems to be set to 3 seconds.

@adamnfish @guardian/commercial-dev 



