### PR TITLE
Update riffraff definition to new lambda name

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -7,4 +7,4 @@ deployments:
     parameters:
       bucket: aws-frontend-artifacts
       fileName: consent-logs.zip
-      functionNames: [-consent-logs-full-lambda-]
+      functionNames: [-consent-logs-lambda-]


### PR DESCRIPTION
The `full` part of the name has been removed from the project in #1.