### PR TITLE
Add a RecordSet and parameters to allow us to launch into subdomains

### DIFF
--- a/cfn.template.yaml
+++ b/cfn.template.yaml
@@ -42,7 +42,6 @@ Resources:
         DNSName: !GetAtt ConsentLoadBalancer.DNSName
         HostedZoneId: !GetAtt ConsentLoadBalancer.CanonicalHostedZoneID
       HostedZoneId: !Ref HostedZoneId
-      # HostedZoneName: String
       Name: !Ref DomainName
       Region: !Ref AWS::Region
       SetIdentifier: version-1

--- a/cfn.template.yaml
+++ b/cfn.template.yaml
@@ -18,6 +18,12 @@ Parameters:
   FrontendSubnets:
     Description: Frontend Subnets to launch ALB into
     Type: List<AWS::EC2::Subnet::Id>
+  HostedZoneId:
+    Description: The HostedZone where the CNAME RecordSet will live in
+    Type: AWS::Route53::HostedZone::Id
+  DomainName:
+    Description: The fully qualified domain name within the hosted zone (has to match Hosted Zone domain)
+    Type: String
 
 Mappings:
   Constants:
@@ -29,6 +35,19 @@ Mappings:
       Value: api
 
 Resources:
+  ALBRecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        DNSName: !GetAtt ConsentLoadBalancer.DNSName
+        HostedZoneId: !GetAtt ConsentLoadBalancer.CanonicalHostedZoneID
+      HostedZoneId: !Ref HostedZoneId
+      # HostedZoneName: String
+      Name: !Ref DomainName
+      Region: !Ref AWS::Region
+      SetIdentifier: version-1
+      Type: A
+
   LambdaRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
This allows us to create a subdomain on any of our frontend domains via the parameters we pass in; this is currently deployed on the current cloudformation.

@guardian/commercial-dev 