### PR TITLE
More testing for the model

### DIFF
--- a/src/model.spec.ts
+++ b/src/model.spec.ts
@@ -8,7 +8,10 @@ const {
   isValidPurposeType,
   isValidConsentString,
   isValidPurposes,
-  isValidBrowserId
+  isValidBrowserId,
+  sourceTypes,
+  purposeTypes,
+  isNonEmpty
 } = _;
 
 describe('parseJson', () => {
@@ -26,7 +29,7 @@ describe('parseJson', () => {
     expect(parseJson('')).toBeNull();
   });
 
-  test('Should not parse an empty object', () => {
+  test('Should not parse an empty object in a string', () => {
     expect(parseJson('{}')).toBeNull();
   });
 
@@ -41,6 +44,10 @@ describe('parseJson', () => {
 });
 
 describe('isNumber', () => {
+  test('Should not accept an empty string', () => {
+    expect(isNumber("")).toBe(false);
+  });
+
   test('All string numbers should pass', () => {
     fc.assert(fc.property(
         fc.integer(),
@@ -54,10 +61,28 @@ describe('isNumber', () => {
   });
 });
 
+describe('isNonEmpty', () => {
+  test('Should be false for an empty string', () => {
+    expect(isNonEmpty("")).toBe(false);
+  });
+  test('Should be true for all non empty strings', () => {
+    const nonEmptyString = fc.string(1, 40).filter(s => s.trim().length > 0);
+    fc.assert(
+      fc.property(nonEmptyString, (nonEmptyRandomString: string) => {
+        expect(isNonEmpty(nonEmptyRandomString)).toBe(true);
+      })
+    );
+  });
+});
+
 describe('isValidSourceType', () => {
   test('should only allow valid source types', () => {
     const sourceTypes: string[] = ['cmp-ui', 'ios', 'www', 'support'];
     expect(sourceTypes.every(isValidSourceType)).toBe(true);
+  });
+
+  test('should not allow an empty string', () => {
+    expect(isValidSourceType("")).toBe(false);
   });
 
   test('should not accept random strings', () => {
@@ -82,6 +107,13 @@ describe('isValidPurposeType', () => {
 });
 
 describe('isValidConsentString', () => {
+  // Consent string tool
+  // http://gdpr-demo.labs.quantcast.com/user-examples/cookie-workshop.html
+  test('Should accept consent strings', () => {
+    const validConsentStrings = ['BOkhG-BOkhG-BAAABAENAAAAAAAAoAA'];
+    validConsentStrings.forEach(consentString => expect(isValidConsentString(consentString)).toBe(true));
+  });
+
   test('Should not accept random strings', () => {
     fc.assert(fc.property(
         fc.unicodeString(),

--- a/src/model.spec.ts
+++ b/src/model.spec.ts
@@ -41,6 +41,174 @@ describe('parseJson', () => {
     fc.assert(
         fc.property(fc.json(), (jsonString: string) => !parseJson(jsonString)));
   });
+
+  describe("iab key",  () => {
+    test("Should not accept invalid types", () => {
+      const invalidType: fc.Arbitrary<any> = fc.anything().filter(anyValue => typeof anyValue !== 'string');
+      fc.assert(
+        fc.property(invalidType, (invalidType: any) => {
+          const invalidObject = Object.assign({}, validObject, {iab: invalidType});
+          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        })
+      );
+    });
+  });
+
+  describe("version key",  () => {
+    const validVersions = ['1'];
+    test("Should only accept valid verions", () => {
+      validVersions.forEach(version =>  {
+        const validObjectWithVersion = Object.assign({}, validObject, {version: version});
+        expect(parseJson(JSON.stringify(validObjectWithVersion))).toMatchObject(validObjectWithVersion);
+      });
+    });
+
+    test("Should not accept invalid verions", () => {
+      const invalidVersions = fc.string().filter(s => !validVersions.includes(s));
+      fc.assert(
+        fc.property(invalidVersions, (invalidVersion: string) => {
+          const invalidObject = Object.assign({}, validObject, {version: invalidVersion});
+          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        })
+      );
+    });
+
+    test("Should not accept invalid types", () => {
+      const invalidType: fc.Arbitrary<any> = fc.anything().filter(anyValue => typeof anyValue !== 'string');
+      fc.assert(
+        fc.property(invalidType, (invalidType: any) => {
+          const invalidObject = Object.assign({}, validObject, {version: invalidType});
+          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        })
+      );
+    });
+  });
+
+  describe("time key",  () => {
+    test("Should only accept valid values", () => {
+      fc.assert(
+        fc.property(fc.integer(), (randomInteger: number) => {
+          const validObjectTime = Object.assign({}, validObject, {time: randomInteger});
+          expect(parseJson(JSON.stringify(validObjectTime))).toMatchObject(validObjectTime);
+        })
+      );
+    });
+
+    test("Should not accept invalid types", () => {
+      const invalidType: fc.Arbitrary<any> = fc.anything().filter(anyValue => typeof anyValue !== 'number');
+      fc.assert(
+        fc.property(invalidType, (invalidType: any) => {
+          const invalidObject = Object.assign({}, validObject, {time: invalidType});
+          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        })
+      );
+    });
+  });
+
+  describe("source key",  () => {
+    test("Should only accept valid source types", () => {
+      sourceTypes.forEach(sourceType =>  {
+        const newValidObject = Object.assign({}, validObject, {source: sourceType});
+        expect(parseJson(JSON.stringify(newValidObject))).toMatchObject(newValidObject);
+      });
+    });
+
+    test("Should not accept invalid source types", () => {
+      const invalidSourceTypes = fc.string().filter(s => !sourceTypes.includes(s));
+      fc.assert(
+        fc.property(invalidSourceTypes, (invalidSourceType: string) => {
+          const invalidObject = Object.assign({}, validObject, {source: invalidSourceType});
+          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        })
+      );
+    });
+
+    test("Should not accept invalid types", () => {
+      const invalidType: fc.Arbitrary<any> = fc.anything().filter(anyValue => typeof anyValue !== 'string');
+      fc.assert(
+        fc.property(invalidType, (invalidType: any) => {
+          const invalidObject = Object.assign({}, validObject, {source: invalidType});
+          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        })
+      );
+    });
+  });
+
+  describe("purposes key",  () => {
+    test("Should accept an empty object", () => {
+      const newValidObject = Object.assign({}, validObject, {purposes: {}});
+      expect(parseJson(JSON.stringify(newValidObject))).toMatchObject(newValidObject);
+    });
+
+    test("Should accept valid purposes", () => {
+      const validPurposeGen = fc.constantFrom(...purposeTypes);
+      fc.assert(
+        fc.property(validPurposeGen, fc.boolean(), (validPurpose: string, randomBoolean: boolean) => {
+          const validObjectWithPurposes = Object.assign({}, validObject, {purposes: {[validPurpose]: randomBoolean}});
+          expect(parseJson(JSON.stringify(validObjectWithPurposes))).toMatchObject(validObjectWithPurposes);
+        })
+      );
+    });
+
+    test("Should reject invalid purposes keys", () => {
+      const invalidPurposeGen = fc.string().filter(randomString => !purposeTypes.includes(randomString));
+      fc.assert(
+        fc.property(invalidPurposeGen,  fc.boolean(), (invalidPurpose: string, randomBoolean: boolean) => {
+          const invalidObject = Object.assign({}, validObject, {purposes: {invalidPurpose: randomBoolean}});
+          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        })
+      );
+    });
+
+    test("Should not accept invalid types", () => {
+      const invalidType: fc.Arbitrary<any> = fc.anything().filter(anyValue => typeof anyValue !== 'object');
+      fc.assert(
+        fc.property(invalidType, (invalidType: any) => {
+          const invalidObject = Object.assign({}, validObject, {purposes: invalidType});
+          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        })
+      );
+    });
+
+    test("Should not accept invalid types for the purposes values", () => {
+      const validPurposeGen = fc.constantFrom(...purposeTypes);
+      const invalidType: fc.Arbitrary<any> = fc.anything()
+        .filter(anyValue => typeof anyValue !== 'boolean' &&  typeof anyValue !== 'undefined');
+      fc.assert(
+        fc.property(validPurposeGen, invalidType, (validPurposeKey: string, invalidType: any) => {
+          const invalidObject = Object.assign({}, validObject, {purposes: {[validPurposeKey]: invalidType}});
+          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        })
+      );
+    });
+
+  });
+
+  describe("browserId key",  () => {
+    test("Should not acccept an empty string", () => {
+      const newInvalidObject = Object.assign({}, validObject, {browserId: ''});
+      expect(parseJson(JSON.stringify(newInvalidObject))).toBeNull();
+    });
+    test("Should accept any non-empty string", () => {
+      const nonEmptyString = fc.string(1, 40).filter(s => s.trim().length > 0);
+      fc.assert(
+        fc.property(nonEmptyString, (nonEmptyRandomString: string) => {
+          const validObjectWithBrowserId = Object.assign({}, validObject, {browserId: nonEmptyRandomString});
+          expect(parseJson(JSON.stringify(validObjectWithBrowserId))).toMatchObject(validObjectWithBrowserId);
+        })
+      );
+    });
+
+    test("Should not accept invalid types", () => {
+      const invalidType: fc.Arbitrary<any> = fc.anything().filter(anyValue => typeof anyValue !== 'string');
+      fc.assert(
+        fc.property(invalidType, (invalidType: any) => {
+          const invalidObject = Object.assign({}, validObject, {browserId: invalidType});
+          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        })
+      );
+    });    
+  });
 });
 
 describe('isNumber', () => {

--- a/src/model.spec.ts
+++ b/src/model.spec.ts
@@ -1,3 +1,5 @@
+
+/* tslint:disable:no-any */
 import fc from 'fast-check';
 
 import {_, parseJson} from './model';
@@ -41,178 +43,188 @@ describe('parseJson', () => {
         fc.property(fc.json(), (jsonString: string) => !parseJson(jsonString)));
   });
 
-  describe("iab key",  () => {
-    test("Should not accept invalid types", () => {
-      const invalidType: fc.Arbitrary<any> = fc.anything().filter(anyValue => typeof anyValue !== 'string');
-      fc.assert(
-        fc.property(invalidType, (invalidType: any) => {
-          const invalidObject = Object.assign({}, validObject, {iab: invalidType});
-          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
-        })
-      );
+  describe('iab key', () => {
+    test('Should not accept invalid types', () => {
+      const invalidType: fc.Arbitrary<any> =
+          fc.anything().filter(anyValue => typeof anyValue !== 'string');
+      fc.assert(fc.property(invalidType, (invalidType: any) => {
+        const invalidObject =
+            Object.assign({}, validObject, {iab: invalidType});
+        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+      }));
     });
   });
 
-  describe("version key",  () => {
+  describe('version key', () => {
     const validVersions = ['1'];
-    test("Should only accept valid verions", () => {
-      validVersions.forEach(version =>  {
-        const validObjectWithVersion = Object.assign({}, validObject, {version: version});
-        expect(parseJson(JSON.stringify(validObjectWithVersion))).toMatchObject(validObjectWithVersion);
+    test('Should only accept valid verions', () => {
+      validVersions.forEach(version => {
+        const validObjectWithVersion =
+            Object.assign({}, validObject, {version});
+        expect(parseJson(JSON.stringify(validObjectWithVersion)))
+            .toMatchObject(validObjectWithVersion);
       });
     });
 
-    test("Should not accept invalid verions", () => {
-      const invalidVersions = fc.string().filter(s => !validVersions.includes(s));
-      fc.assert(
-        fc.property(invalidVersions, (invalidVersion: string) => {
-          const invalidObject = Object.assign({}, validObject, {version: invalidVersion});
-          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
-        })
-      );
+    test('Should not accept invalid verions', () => {
+      const invalidVersions =
+          fc.string().filter(s => !validVersions.includes(s));
+      fc.assert(fc.property(invalidVersions, (invalidVersion: string) => {
+        const invalidObject =
+            Object.assign({}, validObject, {version: invalidVersion});
+        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+      }));
     });
 
-    test("Should not accept invalid types", () => {
-      const invalidType: fc.Arbitrary<any> = fc.anything().filter(anyValue => typeof anyValue !== 'string');
-      fc.assert(
-        fc.property(invalidType, (invalidType: any) => {
-          const invalidObject = Object.assign({}, validObject, {version: invalidType});
-          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
-        })
-      );
-    });
-  });
-
-  describe("time key",  () => {
-    test("Should only accept valid values", () => {
-      fc.assert(
-        fc.property(fc.integer(), (randomInteger: number) => {
-          const validObjectTime = Object.assign({}, validObject, {time: randomInteger});
-          expect(parseJson(JSON.stringify(validObjectTime))).toMatchObject(validObjectTime);
-        })
-      );
-    });
-
-    test("Should not accept invalid types", () => {
-      const invalidType: fc.Arbitrary<any> = fc.anything().filter(anyValue => typeof anyValue !== 'number');
-      fc.assert(
-        fc.property(invalidType, (invalidType: any) => {
-          const invalidObject = Object.assign({}, validObject, {time: invalidType});
-          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
-        })
-      );
+    test('Should not accept invalid types', () => {
+      const invalidType: fc.Arbitrary<any> =
+          fc.anything().filter(anyValue => typeof anyValue !== 'string');
+      fc.assert(fc.property(invalidType, (invalidType: any) => {
+        const invalidObject =
+            Object.assign({}, validObject, {version: invalidType});
+        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+      }));
     });
   });
 
-  describe("source key",  () => {
-    test("Should only accept valid source types", () => {
-      sourceTypes.forEach(sourceType =>  {
-        const newValidObject = Object.assign({}, validObject, {source: sourceType});
-        expect(parseJson(JSON.stringify(newValidObject))).toMatchObject(newValidObject);
+  describe('time key', () => {
+    test('Should only accept valid values', () => {
+      fc.assert(fc.property(fc.integer(), (randomInteger: number) => {
+        const validObjectTime =
+            Object.assign({}, validObject, {time: randomInteger});
+        expect(parseJson(JSON.stringify(validObjectTime)))
+            .toMatchObject(validObjectTime);
+      }));
+    });
+
+    test('Should not accept invalid types', () => {
+      const invalidType: fc.Arbitrary<any> =
+          fc.anything().filter(anyValue => typeof anyValue !== 'number');
+      fc.assert(fc.property(invalidType, (invalidType: any) => {
+        const invalidObject =
+            Object.assign({}, validObject, {time: invalidType});
+        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+      }));
+    });
+  });
+
+  describe('source key', () => {
+    test('Should only accept valid source types', () => {
+      sourceTypes.forEach(sourceType => {
+        const newValidObject =
+            Object.assign({}, validObject, {source: sourceType});
+        expect(parseJson(JSON.stringify(newValidObject)))
+            .toMatchObject(newValidObject);
       });
     });
 
-    test("Should not accept invalid source types", () => {
-      const invalidSourceTypes = fc.string().filter(s => !sourceTypes.includes(s));
-      fc.assert(
-        fc.property(invalidSourceTypes, (invalidSourceType: string) => {
-          const invalidObject = Object.assign({}, validObject, {source: invalidSourceType});
-          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
-        })
-      );
+    test('Should not accept invalid source types', () => {
+      const invalidSourceTypes =
+          fc.string().filter(s => !sourceTypes.includes(s));
+      fc.assert(fc.property(invalidSourceTypes, (invalidSourceType: string) => {
+        const invalidObject =
+            Object.assign({}, validObject, {source: invalidSourceType});
+        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+      }));
     });
 
-    test("Should not accept invalid types", () => {
-      const invalidType: fc.Arbitrary<any> = fc.anything().filter(anyValue => typeof anyValue !== 'string');
-      fc.assert(
-        fc.property(invalidType, (invalidType: any) => {
-          const invalidObject = Object.assign({}, validObject, {source: invalidType});
-          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
-        })
-      );
+    test('Should not accept invalid types', () => {
+      const invalidType: fc.Arbitrary<any> =
+          fc.anything().filter(anyValue => typeof anyValue !== 'string');
+      fc.assert(fc.property(invalidType, (invalidType: any) => {
+        const invalidObject =
+            Object.assign({}, validObject, {source: invalidType});
+        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+      }));
     });
   });
 
-  describe("purposes key",  () => {
-    test("Should accept an empty object", () => {
+  describe('purposes key', () => {
+    test('Should accept an empty object', () => {
       const newValidObject = Object.assign({}, validObject, {purposes: {}});
-      expect(parseJson(JSON.stringify(newValidObject))).toMatchObject(newValidObject);
+      expect(parseJson(JSON.stringify(newValidObject)))
+          .toMatchObject(newValidObject);
     });
 
-    test("Should accept valid purposes", () => {
+    test('Should accept valid purposes', () => {
       const validPurposeGen = fc.constantFrom(...purposeTypes);
-      fc.assert(
-        fc.property(validPurposeGen, fc.boolean(), (validPurpose: string, randomBoolean: boolean) => {
-          const validObjectWithPurposes = Object.assign({}, validObject, {purposes: {[validPurpose]: randomBoolean}});
-          expect(parseJson(JSON.stringify(validObjectWithPurposes))).toMatchObject(validObjectWithPurposes);
-        })
-      );
+      fc.assert(fc.property(
+          validPurposeGen, fc.boolean(),
+          (validPurpose: string, randomBoolean: boolean) => {
+            const validObjectWithPurposes = Object.assign(
+                {}, validObject, {purposes: {[validPurpose]: randomBoolean}});
+            expect(parseJson(JSON.stringify(validObjectWithPurposes)))
+                .toMatchObject(validObjectWithPurposes);
+          }));
     });
 
-    test("Should reject invalid purposes keys", () => {
-      const invalidPurposeGen = fc.string().filter(randomString => !purposeTypes.includes(randomString));
-      fc.assert(
-        fc.property(invalidPurposeGen,  fc.boolean(), (invalidPurpose: string, randomBoolean: boolean) => {
-          const invalidObject = Object.assign({}, validObject, {purposes: {invalidPurpose: randomBoolean}});
-          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
-        })
-      );
+    test('Should reject invalid purposes keys', () => {
+      const invalidPurposeGen = fc.string().filter(
+          randomString => !purposeTypes.includes(randomString));
+      fc.assert(fc.property(
+          invalidPurposeGen, fc.boolean(),
+          (invalidPurpose: string, randomBoolean: boolean) => {
+            const invalidObject = Object.assign(
+                {}, validObject, {purposes: {invalidPurpose: randomBoolean}});
+            expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+          }));
     });
 
-    test("Should not accept invalid types", () => {
-      const invalidType: fc.Arbitrary<any> = fc.anything().filter(anyValue => typeof anyValue !== 'object');
-      fc.assert(
-        fc.property(invalidType, (invalidType: any) => {
-          const invalidObject = Object.assign({}, validObject, {purposes: invalidType});
-          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
-        })
-      );
+    test('Should not accept invalid types', () => {
+      const invalidType: fc.Arbitrary<any> =
+          fc.anything().filter(anyValue => typeof anyValue !== 'object');
+      fc.assert(fc.property(invalidType, (invalidType: any) => {
+        const invalidObject =
+            Object.assign({}, validObject, {purposes: invalidType});
+        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+      }));
     });
 
-    test("Should not accept invalid types for the purposes values", () => {
+    test('Should not accept invalid types for the purposes values', () => {
       const validPurposeGen = fc.constantFrom(...purposeTypes);
-      const invalidType: fc.Arbitrary<any> = fc.anything()
-        .filter(anyValue => typeof anyValue !== 'boolean' &&  typeof anyValue !== 'undefined');
-      fc.assert(
-        fc.property(validPurposeGen, invalidType, (validPurposeKey: string, invalidType: any) => {
-          const invalidObject = Object.assign({}, validObject, {purposes: {[validPurposeKey]: invalidType}});
-          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
-        })
-      );
+      const invalidType: fc.Arbitrary<any> = fc.anything().filter(
+          anyValue =>
+              typeof anyValue !== 'boolean' && typeof anyValue !== 'undefined');
+      fc.assert(fc.property(
+          validPurposeGen, invalidType,
+          (validPurposeKey: string, invalidType: any) => {
+            const invalidObject = Object.assign(
+                {}, validObject, {purposes: {[validPurposeKey]: invalidType}});
+            expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+          }));
     });
-
   });
 
-  describe("browserId key",  () => {
-    test("Should not acccept an empty string", () => {
+  describe('browserId key', () => {
+    test('Should not acccept an empty string', () => {
       const newInvalidObject = Object.assign({}, validObject, {browserId: ''});
       expect(parseJson(JSON.stringify(newInvalidObject))).toBeNull();
     });
-    test("Should accept any non-empty string", () => {
+    test('Should accept any non-empty string', () => {
       const nonEmptyString = fc.string(1, 40).filter(s => s.trim().length > 0);
-      fc.assert(
-        fc.property(nonEmptyString, (nonEmptyRandomString: string) => {
-          const validObjectWithBrowserId = Object.assign({}, validObject, {browserId: nonEmptyRandomString});
-          expect(parseJson(JSON.stringify(validObjectWithBrowserId))).toMatchObject(validObjectWithBrowserId);
-        })
-      );
+      fc.assert(fc.property(nonEmptyString, (nonEmptyRandomString: string) => {
+        const validObjectWithBrowserId =
+            Object.assign({}, validObject, {browserId: nonEmptyRandomString});
+        expect(parseJson(JSON.stringify(validObjectWithBrowserId)))
+            .toMatchObject(validObjectWithBrowserId);
+      }));
     });
 
-    test("Should not accept invalid types", () => {
-      const invalidType: fc.Arbitrary<any> = fc.anything().filter(anyValue => typeof anyValue !== 'string');
-      fc.assert(
-        fc.property(invalidType, (invalidType: any) => {
-          const invalidObject = Object.assign({}, validObject, {browserId: invalidType});
-          expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
-        })
-      );
-    });    
+    test('Should not accept invalid types', () => {
+      const invalidType: fc.Arbitrary<any> =
+          fc.anything().filter(anyValue => typeof anyValue !== 'string');
+      fc.assert(fc.property(invalidType, (invalidType: any) => {
+        const invalidObject =
+            Object.assign({}, validObject, {browserId: invalidType});
+        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+      }));
+    });
   });
 });
 
 describe('isNumber', () => {
   test('Should not accept an empty string', () => {
-    expect(isNumber("")).toBe(false);
+    expect(isNumber('')).toBe(false);
   });
 
   test('All string numbers should pass', () => {
@@ -230,15 +242,13 @@ describe('isNumber', () => {
 
 describe('isNonEmpty', () => {
   test('Should be false for an empty string', () => {
-    expect(isNonEmpty("")).toBe(false);
+    expect(isNonEmpty('')).toBe(false);
   });
   test('Should be true for all non empty strings', () => {
     const nonEmptyString = fc.string(1, 40).filter(s => s.trim().length > 0);
-    fc.assert(
-      fc.property(nonEmptyString, (nonEmptyRandomString: string) => {
-        expect(isNonEmpty(nonEmptyRandomString)).toBe(true);
-      })
-    );
+    fc.assert(fc.property(nonEmptyString, (nonEmptyRandomString: string) => {
+      expect(isNonEmpty(nonEmptyRandomString)).toBe(true);
+    }));
   });
 });
 
@@ -248,7 +258,7 @@ describe('isValidSourceType', () => {
   });
 
   test('should not allow an empty string', () => {
-    expect(isValidSourceType("")).toBe(false);
+    expect(isValidSourceType('')).toBe(false);
   });
 
   test('should not accept random strings', () => {
@@ -275,7 +285,9 @@ describe('isValidConsentString', () => {
   // http://gdpr-demo.labs.quantcast.com/user-examples/cookie-workshop.html
   test('Should accept consent strings', () => {
     const validConsentStrings = ['BOkhG-BOkhG-BAAABAENAAAAAAAAoAA'];
-    validConsentStrings.forEach(consentString => expect(isValidConsentString(consentString)).toBe(true));
+    validConsentStrings.forEach(
+        consentString =>
+            expect(isValidConsentString(consentString)).toBe(true));
   });
 
   test('Should not accept random strings', () => {

--- a/src/model.spec.ts
+++ b/src/model.spec.ts
@@ -245,7 +245,6 @@ describe('isNonEmpty', () => {
 
 describe('isValidSourceType', () => {
   test('should only allow valid source types', () => {
-    const sourceTypes: string[] = ['cmp-ui', 'ios', 'www', 'support'];
     expect(sourceTypes.every(isValidSourceType)).toBe(true);
   });
 
@@ -262,8 +261,6 @@ describe('isValidSourceType', () => {
 
 describe('isValidPurposeType', () => {
   test('should only allow valid purpose types', () => {
-    const purposeTypes =
-        ['essential', 'performance', 'functionality', 'personaliseaAds'];
     expect(purposeTypes.every(isValidPurposeType)).toBe(true);
   });
 
@@ -291,8 +288,7 @@ describe('isValidConsentString', () => {
 });
 
 describe('isValidPurposes', () => {
-  const purposesArbitrary = fc.constantFrom(
-      'essential', 'performance', 'functionality', 'personaliseaAds');
+  const purposesArbitrary = fc.constantFrom(...purposeTypes);
 
   test('Should accept valid purposes', () => {
     const validPurposesListArbitrary = fc.object(new fc.ObjectConstraints(

--- a/src/model.spec.ts
+++ b/src/model.spec.ts
@@ -16,6 +16,10 @@ describe('parseJson', () => {
     expect(parseJson('')).toBeNull();
   });
 
+  test('Should not parse an empty object', () => {
+    expect(parseJson('{}')).toBeNull();
+  });
+
   test('Should parse an object with all keys', () => {
     const validObject = {iab: 'test', version: '1', time: 123};
     expect(parseJson(JSON.stringify(validObject))).toMatchObject(validObject);
@@ -31,13 +35,13 @@ describe('isNumber', () => {
   test('All string numbers should pass', () => {
     fc.assert(fc.property(
         fc.integer(),
-        (randomNumber: number) => !isNumber(randomNumber.toString())));
+        (randomNumber: number) => isNumber(randomNumber.toString())));
     fc.assert(fc.property(
         fc.float(),
-        (randomNumber: number) => !isNumber(randomNumber.toString())));
+        (randomNumber: number) => isNumber(randomNumber.toString())));
     fc.assert(fc.property(
         fc.bigInt(),
-        (randomNumber: bigint) => !isNumber(randomNumber.toString())));
+        (randomNumber: bigint) => isNumber(randomNumber.toString())));
   });
 });
 

--- a/src/model.spec.ts
+++ b/src/model.spec.ts
@@ -12,6 +12,16 @@ const {
 } = _;
 
 describe('parseJson', () => {
+  const validKeys = ['iab', 'version', 'time'];
+  const validObject = {
+    iab: 'BOkNAntOkNAntAAABAENAAAAAAAAoAA',
+    version: '1',
+    time: 123,
+    source: 'www',
+    purposes: [],
+    browserId: 'abc123'
+  };
+
   test('Should not parse an empty string', () => {
     expect(parseJson('')).toBeNull();
   });
@@ -21,7 +31,6 @@ describe('parseJson', () => {
   });
 
   test('Should parse an object with all keys', () => {
-    const validObject = {iab: 'test', version: '1', time: 123};
     expect(parseJson(JSON.stringify(validObject))).toMatchObject(validObject);
   });
 

--- a/src/model.spec.ts
+++ b/src/model.spec.ts
@@ -15,7 +15,6 @@ const {
 } = _;
 
 describe('parseJson', () => {
-  const validKeys = ['iab', 'version', 'time'];
   const validObject = {
     iab: 'BOkNAntOkNAntAAABAENAAAAAAAAoAA',
     version: '1',

--- a/src/model.spec.ts
+++ b/src/model.spec.ts
@@ -320,18 +320,6 @@ describe('isValidPurposes', () => {
         invalidKeysPurposesListArbitrary,
         (invalidPurposes) => !isValidPurposes(invalidPurposes)));
   });
-
-  test('Should not accept other types in values', () => {
-    const invalidValuesPurposesListArbitrary =
-        fc.object(new fc.ObjectConstraints(
-                      purposesArbitrary, [fc.string(), fc.integer()], 1, 5,
-                      false, false))
-            .filter(o => Object.keys(o).length > 0);
-
-    fc.assert(fc.property(
-        invalidValuesPurposesListArbitrary,
-        (invalidPurposes) => !isValidPurposes(invalidPurposes)));
-  });
 });
 
 describe('isValidBrowserId', () => {

--- a/src/model.ts
+++ b/src/model.ts
@@ -65,8 +65,16 @@ const isValidVersion = (version: string): boolean => isNumber(version)
 const isValidTime = (time: number): boolean => isNumber(time)
 
 const validateObject = (jsonObject: object): boolean => {
-  const keysToCheck: string[] = ['iab', 'version', 'time'];
-  return keysToCheck.every((key) => key in jsonObject);
+  const keysToCheck = {
+    'iab': isValidConsentString,
+    'version': isValidVersion,
+    'time': isValidTime,
+    'source': isValidSourceType,
+    'purposes': isValidPurposes,
+    'browserId': isValidBrowserId
+  };
+  // @ts-ignore: This is where we need to convert between types
+  return Object.keys(keysToCheck).every((key) => key in jsonObject && keysToCheck[key](jsonObject[key]));
 };
 
 const parseJson = (json: string): CMPCookie|null => {

--- a/src/model.ts
+++ b/src/model.ts
@@ -31,6 +31,9 @@ type CMPCookie = {
   browserId: string
 };
 
+const acceptedVersions: string[] = ['1'];
+
+const isNonEmpty = (value: string): boolean => value.trim().length > 0
 // IsNumber is used to access an enum as a string[]
 const isNumber = (value: string|number): boolean => isNaN(Number(value)) === false;
 const sourceTypes: string[] = Object.keys(SourceType).filter(source => !isNumber(source));

--- a/src/model.ts
+++ b/src/model.ts
@@ -33,11 +33,14 @@ type CMPCookie = {
 
 const acceptedVersions: string[] = ['1'];
 
-const isNonEmpty = (value: string): boolean => value.trim().length > 0
+const isNonEmpty = (value: string): boolean => value.trim().length > 0;
 // IsNumber is used to access an enum as a string[]
-const isNumber = (value: string|number): boolean => isNonEmpty(value.toString()) && isNaN(Number(value)) === false;
-const sourceTypes: string[] = Object.keys(SourceType).filter(source => !isNumber(source));
-const purposeTypes: string[] = Object.keys(PurposeType).filter(purpose => !isNumber(purpose));
+const isNumber = (value: string|number): boolean =>
+    isNonEmpty(value.toString()) && isNaN(Number(value)) === false;
+const sourceTypes: string[] =
+    Object.keys(SourceType).filter(source => !isNumber(source));
+const purposeTypes: string[] =
+    Object.keys(PurposeType).filter(purpose => !isNumber(purpose));
 
 const isValidSourceType = (sourceType: string): boolean =>
     sourceTypes.includes(sourceType);
@@ -57,15 +60,17 @@ const isValidConsentString = (base64ConsentString: string): boolean => {
 };
 
 const isValidPurposes = (purposeList: PurposeList): boolean =>
-  typeof purposeList === 'object' &&
-  Object.keys(purposeList).every(isValidPurposeType) &&
-  Object.values(purposeList).every(value => typeof value === 'boolean');
+    typeof purposeList === 'object' &&
+    Object.keys(purposeList).every(isValidPurposeType) &&
+    Object.values(purposeList).every(value => typeof value === 'boolean');
 
 const isValidBrowserId = (browserId: string): boolean => isNonEmpty(browserId);
 
-const isValidVersion = (version: string): boolean => acceptedVersions.includes(version);
+const isValidVersion = (version: string): boolean =>
+    acceptedVersions.includes(version);
 
-const isValidTime = (time: number): boolean => typeof time === 'number' && isNumber(time)
+const isValidTime = (time: number): boolean =>
+    typeof time === 'number' && isNumber(time);
 
 const validateObject = (jsonObject: object): boolean => {
   const keysToCheck = {
@@ -76,8 +81,10 @@ const validateObject = (jsonObject: object): boolean => {
     'purposes': isValidPurposes,
     'browserId': isValidBrowserId
   };
-  // @ts-ignore: This is where we need to convert between types
-  return Object.keys(keysToCheck).every((key) => key in jsonObject && keysToCheck[key](jsonObject[key]));
+  return Object
+      .keys(keysToCheck)
+      // @ts-ignore: This is where we need to convert between types
+      .every((key) => key in jsonObject && keysToCheck[key](jsonObject[key]));
 };
 
 const parseJson = (json: string): CMPCookie|null => {

--- a/src/model.ts
+++ b/src/model.ts
@@ -32,7 +32,7 @@ type CMPCookie = {
 };
 
 // IsNumber is used to access an enum as a string[]
-const isNumber = (value: string): boolean => isNaN(Number(value)) === false;
+const isNumber = (value: string|number): boolean => isNaN(Number(value)) === false;
 const sourceTypes: string[] = Object.keys(SourceType).filter(source => !isNumber(source));
 const purposeTypes: string[] = Object.keys(PurposeType).filter(purpose => !isNumber(purpose));
 
@@ -59,6 +59,10 @@ const isValidPurposes = (purposeList: PurposeList): boolean =>
 
 const isValidBrowserId = (browserId: string): boolean =>
     browserId.trim().length > 0;
+
+const isValidVersion = (version: string): boolean => isNumber(version)
+
+const isValidTime = (time: number): boolean => isNumber(time)
 
 const validateObject = (jsonObject: object): boolean => {
   const keysToCheck: string[] = ['iab', 'version', 'time'];

--- a/src/model.ts
+++ b/src/model.ts
@@ -32,9 +32,9 @@ type CMPCookie = {
 };
 
 // IsNumber is used to access an enum as a string[]
-const isNumber = (value: string): boolean => isNaN(Number(value)) !== false;
-const sourceTypes: string[] = Object.keys(SourceType).filter(isNumber);
-const purposeTypes: string[] = Object.keys(PurposeType).filter(isNumber);
+const isNumber = (value: string): boolean => isNaN(Number(value)) === false;
+const sourceTypes: string[] = Object.keys(SourceType).filter(source => !isNumber(source));
+const purposeTypes: string[] = Object.keys(PurposeType).filter(purpose => !isNumber(purpose));
 
 const isValidSourceType = (sourceType: string): boolean =>
     sourceTypes.includes(sourceType);

--- a/src/model.ts
+++ b/src/model.ts
@@ -35,7 +35,7 @@ const acceptedVersions: string[] = ['1'];
 
 const isNonEmpty = (value: string): boolean => value.trim().length > 0
 // IsNumber is used to access an enum as a string[]
-const isNumber = (value: string|number): boolean => isNaN(Number(value)) === false;
+const isNumber = (value: string|number): boolean => isNonEmpty(value.toString()) && isNaN(Number(value)) === false;
 const sourceTypes: string[] = Object.keys(SourceType).filter(source => !isNumber(source));
 const purposeTypes: string[] = Object.keys(PurposeType).filter(purpose => !isNumber(purpose));
 
@@ -57,15 +57,15 @@ const isValidConsentString = (base64ConsentString: string): boolean => {
 };
 
 const isValidPurposes = (purposeList: PurposeList): boolean =>
-    Object.keys(purposeList).every(isValidPurposeType) &&
-    Object.values(purposeList).every(value => typeof value === 'boolean');
+  typeof purposeList === 'object' &&
+  Object.keys(purposeList).every(isValidPurposeType) &&
+  Object.values(purposeList).every(value => typeof value === 'boolean');
 
-const isValidBrowserId = (browserId: string): boolean =>
-    browserId.trim().length > 0;
+const isValidBrowserId = (browserId: string): boolean => isNonEmpty(browserId);
 
-const isValidVersion = (version: string): boolean => isNumber(version)
+const isValidVersion = (version: string): boolean => acceptedVersions.includes(version);
 
-const isValidTime = (time: number): boolean => isNumber(time)
+const isValidTime = (time: number): boolean => typeof time === 'number' && isNumber(time)
 
 const validateObject = (jsonObject: object): boolean => {
   const keysToCheck = {
@@ -99,5 +99,8 @@ export let _ = {
   isValidPurposeType,
   isValidConsentString,
   isValidPurposes,
-  isValidBrowserId
+  isValidBrowserId,
+  sourceTypes,
+  purposeTypes,
+  isNonEmpty,
 };


### PR DESCRIPTION
This does the following:
 - Adds more tests for `parseJson`; the entry point for validation
 - Adds more empty cases tests
 - Updates any of the code appropriately for the tests
 - Uses references derived from the types rather than duplication within the tests

One thing to note is that I have used type tests only within the `parseJson` section as this is passed as a string, whilst tests for pure Typescript code is left to the bounds of the types it receives and returns.

@adamnfish @guardian/commercial-dev 
