### PR TITLE
Require purposes

### DIFF
--- a/src/amp.spec.ts
+++ b/src/amp.spec.ts
@@ -21,7 +21,7 @@ const oneToTwentyFour = [
   13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
 ];
 
-describe('All allowed purposes', () => {
+describe('All allowed IAB purposes', () => {
   test('Should always be equal to array of 1 to 24', () => {
     expect(ALL_ALLOWED_PURPOSES).toEqual(oneToTwentyFour);
   });
@@ -240,14 +240,84 @@ describe('fullAmpConsent', () => {
 });
 
 describe('consentModelFrom', () => {
-  test('Should validate for a true consent', () => {
-    const fullConsent = consentModelFrom('abc', true);
-    expect(parseJson(JSON.stringify(fullConsent))).toEqual(fullConsent);
+  describe('full consent', () => {
+    test('Generated consent object is valid', () => {
+      const consentObject = consentModelFrom('abc', true);
+      const iabConsent = new ConsentString(consentObject.iab);
+      // expect that checks IAB consent string is correct
+    });
+
+    test('creates a fully consented IAB string', () => {
+      const fullConsent = consentModelFrom('abc', true);
+      expect(parseJson(JSON.stringify(fullConsent))).toEqual(fullConsent);
+    });
+
+    test('creates a fully consented IAB string', () => {
+      const fullConsent = consentModelFrom('abc', true);
+      expect(parseJson(JSON.stringify(fullConsent))).toEqual(fullConsent);
+    });
+
+    describe('PECR purposes', () => {
+      test('should set essential to true', () => {
+        const consentObject = consentModelFrom('abc', true);
+        expect(consentObject.purposes.essential).toEqual(true);
+      });
+
+      test('should set performance to true', () => {
+        const consentObject = consentModelFrom('abc', true);
+        expect(consentObject.purposes.performance).toEqual(true);
+      });
+
+      test('should set functionality to true', () => {
+        const consentObject = consentModelFrom('abc', true);
+        expect(consentObject.purposes.functionality).toEqual(true);
+      });
+
+      test('should set presonalisedAdvertising to true', () => {
+        const consentObject = consentModelFrom('abc', true);
+        expect(consentObject.purposes.presonalisedAdvertising).toEqual(true);
+      });
+    });
   });
 
-  test('Should validate for a false consent', () => {
-    const noConsent = consentModelFrom('abc', false);
-    expect(parseJson(JSON.stringify(noConsent))).toEqual(noConsent);
+
+  describe('without consent', () => {
+    test('Generated consent object is valid', () => {
+      const noConsent = consentModelFrom('abc', false);
+      expect(parseJson(JSON.stringify(noConsent))).toEqual(noConsent);
+    });
+
+    test('creates a fully consented IAB string', () => {
+      const fullConsent = consentModelFrom('abc', false);
+      expect(parseJson(JSON.stringify(fullConsent))).toEqual(fullConsent);
+    });
+
+    test('uses the provided amp user ID as the browser ID', () => {
+      const consentObject = consentModelFrom('abc', false);
+      expect(consentObject.browserId).toEqual('abc');
+    });
+
+    describe('PECR purposes', () => {
+      test('should set essential to false', () => {
+        const consentObject = consentModelFrom('abc', false);
+        expect(consentObject.purposes.essential).toEqual(false);
+      });
+
+      test('should set performance to false', () => {
+        const consentObject = consentModelFrom('abc', false);
+        expect(consentObject.purposes.performance).toEqual(false);
+      });
+
+      test('should set functionality to false', () => {
+        const consentObject = consentModelFrom('abc', false);
+        expect(consentObject.purposes.functionality).toEqual(false);
+      });
+
+      test('should set presonalisedAdvertising to false', () => {
+        const consentObject = consentModelFrom('abc', false);
+        expect(consentObject.purposes.presonalisedAdvertising).toEqual(false);
+      });
+    });
   });
 });
 

--- a/src/amp.ts
+++ b/src/amp.ts
@@ -44,6 +44,7 @@ const consentModelFrom = (ampUserId: string, ampConsent: boolean): CMPCookie =>
         'essential': ampConsent,
         'performance': ampConsent,
         'functionality': ampConsent,
+        'presonalisedAdvertising': ampConsent,
       },
     });
 

--- a/src/model.spec.ts
+++ b/src/model.spec.ts
@@ -22,7 +22,7 @@ describe('parseJson', () => {
     version: '1',
     time: 123,
     source: 'www',
-    purposes: [],
+    purposes: {},
     browserId: 'abc123'
   };
 
@@ -283,14 +283,14 @@ describe('isValidPurposeType', () => {
 describe('isValidConsentString', () => {
   // Consent string tool
   // http://gdpr-demo.labs.quantcast.com/user-examples/cookie-workshop.html
-  test('Should accept consent strings', () => {
+  test('Should accept IAB consent strings', () => {
     const validConsentStrings = ['BOkhG-BOkhG-BAAABAENAAAAAAAAoAA'];
     validConsentStrings.forEach(
         consentString =>
             expect(isValidConsentString(consentString)).toBe(true));
   });
 
-  test('Should not accept random strings', () => {
+  test('Should not accept random IAB consent strings', () => {
     fc.assert(fc.property(
         fc.unicodeString(),
         (randomUnicodeString: string) =>

--- a/src/model.ts
+++ b/src/model.ts
@@ -60,10 +60,16 @@ const isValidConsentString = (base64ConsentString: string): boolean => {
   }
 };
 
-const isValidPurposes = (purposeList: PurposeList): boolean =>
-    typeof purposeList === 'object' &&
-    Object.keys(purposeList).every(isValidPurposeType) &&
-    Object.values(purposeList).every(value => typeof value === 'boolean');
+const isValidPurposes = (purposeList: PurposeList): boolean => {
+  const keys = Object.keys(purposeList);
+  // correct type,
+  // all keys are valid purposes,
+  // all purposes are present,
+  // all keys are booleans
+  return typeof purposeList === 'object' && keys.every(isValidPurposeType) &&
+      purposeTypes.every((key) => keys.includes(key)) &&
+      Object.values(purposeList).every(value => typeof value === 'boolean');
+};
 
 const isValidBrowserId = (browserId: string): boolean => isNonEmpty(browserId);
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -4,6 +4,7 @@ enum PurposeType {
   'essential',
   'performance',
   'functionality',
+  'presonalisedAdvertising'
 }
 // See:
 // https://www.typescriptlang.org/docs/handbook/enums.html#enums-at-compile-time


### PR DESCRIPTION
This PR includes changes in this previous PR, let's review and merge that first:
https://github.com/guardian/consent-logs/pull/13

The Guardian/PECR purposes (functional, performance and personalisedAdvertising) are now required in the record body. Previously we were ensuring the records were valid keys, but not that all keys were present.

This also does a little renaming, I've tried to make it a little clearer where we're talking about IAB bits vs consent in general.
