### PR TITLE
Add detailed and specific error feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gts": "^0.9.0",
     "jest": "^24.8.0",
     "jest-date-mock": "^1.0.7",
+    "pretty-format": "^24.9.0",
     "node-riffraff-artefact": "^2.0.1",
     "nodemon": "^1.19.0",
     "ts-jest": "^24.0.2",

--- a/src/amp.spec.ts
+++ b/src/amp.spec.ts
@@ -4,8 +4,8 @@ import fc from 'fast-check';
 import {advanceTo, clear} from 'jest-date-mock';
 
 import {_} from './amp';
-import {parseJson} from './model';
 import {isCmpError} from './errors';
+import {parseJson} from './model';
 import VENDOR_LIST from './resources/vendorlist.json';
 
 const {

--- a/src/amp.spec.ts
+++ b/src/amp.spec.ts
@@ -4,9 +4,12 @@ import fc from 'fast-check';
 import {advanceTo, clear} from 'jest-date-mock';
 
 import {_} from './amp';
+import {addCmpExtensions} from './cmpErrorTestExtensions';
 import {isCmpError} from './errors';
 import {parseJson} from './model';
 import VENDOR_LIST from './resources/vendorlist.json';
+
+addCmpExtensions();
 
 const {
   ALL_ALLOWED_PURPOSES,
@@ -338,8 +341,7 @@ describe('getAmpConsentBody', () => {
     Object.keys(validBody).forEach(key => {
       const invalidBody = Object.assign({}, validBody, {[key]: undefined});
       // Stringify will remove any keys with a value of undefined
-      expect(isCmpError(getAmpConsentBody(JSON.stringify(invalidBody))))
-          .toBeTruthy();
+      expect(getAmpConsentBody(JSON.stringify(invalidBody))).toBeCmpError();
     });
   });
 
@@ -353,8 +355,8 @@ describe('getAmpConsentBody', () => {
           fc.assert(fc.property(nonStringType, (randomType: any) => {
             const invalidBody =
                 Object.assign({}, validBody, {[key]: randomType});
-            expect(isCmpError(getAmpConsentBody(JSON.stringify(invalidBody))))
-                .toBeTruthy();
+            expect(getAmpConsentBody(JSON.stringify(invalidBody)))
+                .toBeCmpError();
           }));
         });
       });
@@ -368,8 +370,7 @@ describe('getAmpConsentBody', () => {
         fc.assert(fc.property(nonStringType, (randomType: any) => {
           const invalidBody =
               Object.assign({}, validBody, {consentState: randomType});
-          expect(isCmpError(getAmpConsentBody(JSON.stringify(invalidBody))))
-              .toBeTruthy();
+          expect(getAmpConsentBody(JSON.stringify(invalidBody))).toBeCmpError();
         }));
       });
 });

--- a/src/amp.spec.ts
+++ b/src/amp.spec.ts
@@ -5,6 +5,7 @@ import {advanceTo, clear} from 'jest-date-mock';
 
 import {_} from './amp';
 import {parseJson} from './model';
+import {isCmpError} from './errors';
 import VENDOR_LIST from './resources/vendorlist.json';
 
 const {
@@ -337,7 +338,8 @@ describe('getAmpConsentBody', () => {
     Object.keys(validBody).forEach(key => {
       const invalidBody = Object.assign({}, validBody, {[key]: undefined});
       // Stringify will remove any keys with a value of undefined
-      expect(getAmpConsentBody(JSON.stringify(invalidBody))).toEqual(undefined);
+      expect(isCmpError(getAmpConsentBody(JSON.stringify(invalidBody))))
+          .toBeTruthy();
     });
   });
 
@@ -351,8 +353,8 @@ describe('getAmpConsentBody', () => {
           fc.assert(fc.property(nonStringType, (randomType: any) => {
             const invalidBody =
                 Object.assign({}, validBody, {[key]: randomType});
-            expect(getAmpConsentBody(JSON.stringify(invalidBody)))
-                .toEqual(undefined);
+            expect(isCmpError(getAmpConsentBody(JSON.stringify(invalidBody))))
+                .toBeTruthy();
           }));
         });
       });
@@ -366,8 +368,8 @@ describe('getAmpConsentBody', () => {
         fc.assert(fc.property(nonStringType, (randomType: any) => {
           const invalidBody =
               Object.assign({}, validBody, {consentState: randomType});
-          expect(getAmpConsentBody(JSON.stringify(invalidBody)))
-              .toEqual(undefined);
+          expect(isCmpError(getAmpConsentBody(JSON.stringify(invalidBody))))
+              .toBeTruthy();
         }));
       });
 });

--- a/src/amp.spec.ts
+++ b/src/amp.spec.ts
@@ -277,9 +277,9 @@ describe('consentModelFrom', () => {
         expect(consentObject.purposes.functionality).toEqual(true);
       });
 
-      test('should set presonalisedAdvertising to true', () => {
+      test('should set personalisedAdvertising to true', () => {
         const consentObject = consentModelFrom('abc', true);
-        expect(consentObject.purposes.presonalisedAdvertising).toEqual(true);
+        expect(consentObject.purposes.personalisedAdvertising).toEqual(true);
       });
     });
   });
@@ -317,9 +317,9 @@ describe('consentModelFrom', () => {
         expect(consentObject.purposes.functionality).toEqual(false);
       });
 
-      test('should set presonalisedAdvertising to false', () => {
+      test('should set personalisedAdvertising to false', () => {
         const consentObject = consentModelFrom('abc', false);
-        expect(consentObject.purposes.presonalisedAdvertising).toEqual(false);
+        expect(consentObject.purposes.personalisedAdvertising).toEqual(false);
       });
     });
   });

--- a/src/amp.ts
+++ b/src/amp.ts
@@ -45,7 +45,7 @@ const consentModelFrom = (ampUserId: string, ampConsent: boolean): CMPCookie =>
         'essential': ampConsent,
         'performance': ampConsent,
         'functionality': ampConsent,
-        'presonalisedAdvertising': ampConsent,
+        'personalisedAdvertising': ampConsent,
       },
     });
 

--- a/src/cmpErrorTestExtensions.ts
+++ b/src/cmpErrorTestExtensions.ts
@@ -1,0 +1,84 @@
+import prettyFormat from 'pretty-format';
+
+import {CmpError, cmpError, collectCmpErrors, collectCmpErrors4, collectCmpErrors6, isCmpError} from './errors';
+
+const addCmpExtensions = () => {
+  expect.extend({
+    toBeCmpError(received) {
+      if (isCmpError(received)) {
+        if (received.message.length > 0) {
+          return {
+            message: () =>
+                `expected ${prettyFormat(received)} to be a CmpError`,
+            pass: true,
+          };
+        } else {
+          return {
+            message: () =>
+                `expected a non-empty string for the CmpError error message, ${
+                    prettyFormat(received)}`,
+            pass: false,
+          };
+        }
+      } else {
+        return {
+          message: () => `expected ${prettyFormat(received)} to be a CmpError`,
+          pass: false,
+        };
+      }
+    },
+    toNotBeCmpError(received) {
+      if (isCmpError(received)) {
+        return {
+          message: () =>
+              `expected ${prettyFormat(received)} not to be a CmpError`,
+          pass: false,
+        };
+      } else {
+        return {
+          message: () =>
+              `expected ${prettyFormat(received)} not to be a CmpError`,
+          pass: true,
+        };
+      }
+    },
+    toBeCmpErrorWithMessage(received, expected) {
+      if (isCmpError(received)) {
+        if (received.message === expected) {
+          return {
+            message: () =>
+                `expected ${prettyFormat(received)} to be a CmpError message ${
+                    prettyFormat(expected)}`,
+            pass: true,
+          };
+        } else {
+          return {
+            message: () => `expected error message ${
+                prettyFormat(
+                    received.message)} to be ${prettyFormat(expected)}`,
+            pass: false,
+          };
+        }
+      } else {
+        return {
+          message: () => `expected ${
+              prettyFormat(received)} to be a CmpError with message ${
+              prettyFormat(expected)}`,
+          pass: false,
+        };
+      }
+    }
+  });
+};
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeCmpError(): R;
+      toNotBeCmpError(): R;
+      toBeCmpErrorWithMessage(message: string): R;
+    }
+  }
+}
+
+export {addCmpExtensions};

--- a/src/errors.spec.ts
+++ b/src/errors.spec.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-any */
 import fc from 'fast-check';
 
-import {CmpError, cmpError, isCmpError, collectCmpErrors, collectCmpErrors4} from './errors';
+import {CmpError, cmpError, collectCmpErrors4, collectCmpErrors6, isCmpError} from './errors';
 
 describe('isCmpError', () => {
   test('returns true for a value that is a cmpError', () => {
@@ -10,17 +10,17 @@ describe('isCmpError', () => {
   });
 
   test('returns false for a value that is not a CmpError', () => {
-    const value: string|CmpError = "not an error";
+    const value: string|CmpError = 'not an error';
     expect(isCmpError(value)).toBeFalsy();
   });
 });
 
 describe('collectCmpErrors4', () => {
   test('retuns the four successful values if all four succeeded', () => {
-    const a: string|CmpError = "string";
+    const a: string|CmpError = 'string';
     const b: number|CmpError = 1;
     const c: boolean|CmpError = false;
-    const d: Array<number>|CmpError = [1, 2, 3];
+    const d: number[]|CmpError = [1, 2, 3];
     expect(collectCmpErrors4(a, b, c, d)).toEqual([a, b, c, d]);
   });
 
@@ -28,31 +28,31 @@ describe('collectCmpErrors4', () => {
     const a: string|CmpError = cmpError('first item failure');
     const b: number|CmpError = 1;
     const c: boolean|CmpError = false;
-    const d: Array<number>|CmpError = [1, 2, 3];
+    const d: number[]|CmpError = [1, 2, 3];
     expect(isCmpError(collectCmpErrors4(a, b, c, d))).toBeTruthy();
   });
 
   test('retuns a CmpError if the second item is a failure', () => {
-    const a: string|CmpError = "string";
+    const a: string|CmpError = 'string';
     const b: number|CmpError = cmpError('second item failure');
     const c: boolean|CmpError = false;
-    const d: Array<number>|CmpError = [1, 2, 3];
+    const d: number[]|CmpError = [1, 2, 3];
     expect(isCmpError(collectCmpErrors4(a, b, c, d))).toBeTruthy();
   });
 
   test('retuns a CmpError if the third item is a failure', () => {
-    const a: string|CmpError = "string";
+    const a: string|CmpError = 'string';
     const b: number|CmpError = 1;
     const c: boolean|CmpError = cmpError('third item failure');
-    const d: Array<number>|CmpError = [1, 2, 3];
+    const d: number[]|CmpError = [1, 2, 3];
     expect(isCmpError(collectCmpErrors4(a, b, c, d))).toBeTruthy();
   });
 
   test('retuns a CmpError if the fourth item is a failure', () => {
-    const a: string|CmpError = "string";
+    const a: string|CmpError = 'string';
     const b: number|CmpError = 1;
     const c: boolean|CmpError = false;
-    const d: Array<number>|CmpError = cmpError('fourth item failure');
+    const d: number[]|CmpError = cmpError('fourth item failure');
     expect(isCmpError(collectCmpErrors4(a, b, c, d))).toBeTruthy();
   });
 
@@ -60,10 +60,10 @@ describe('collectCmpErrors4', () => {
     const a: string|CmpError = cmpError('test error message');
     const b: number|CmpError = 1;
     const c: boolean|CmpError = false;
-    const d: Array<number>|CmpError = [1, 2, 3];
+    const d: number[]|CmpError = [1, 2, 3];
     const result = collectCmpErrors4(a, b, c, d);
-    if(isCmpError(result)) {
-      expect(result.message).toEqual("test error message");
+    if (isCmpError(result)) {
+      expect(result.message).toEqual('test error message');
     } else {
       fail('call should have returned a CmpError instance');
     }
@@ -73,47 +73,114 @@ describe('collectCmpErrors4', () => {
     const a: string|CmpError = cmpError('test error message');
     const b: number|CmpError = cmpError('another error message');
     const c: boolean|CmpError = false;
-    const d: Array<number>|CmpError = [1, 2, 3];
+    const d: number[]|CmpError = [1, 2, 3];
     const result = collectCmpErrors4(a, b, c, d);
-    if(isCmpError(result)) {
-      expect(result.message).toEqual("test error message, another error message");
+    if (isCmpError(result)) {
+      expect(result.message)
+          .toEqual('test error message, another error message');
     } else {
       fail('call should have returned a CmpError instance');
     }
   });
 });
 
-describe('collectCmpErrors', () => {
-  test('retuns the successful values if they all succeeded', () => {
-    const generator = fc.array(fc.integer());
-    fc.assert(fc.property(generator, (arr) => {
-      expect(collectCmpErrors(arr)).toEqual(arr);
-    }));
+describe('collectCmpErrors6', () => {
+  test('retuns the four successful values if all six succeeded', () => {
+    const a: string|CmpError = 'string';
+    const b: number|CmpError = 1;
+    const c: boolean|CmpError = false;
+    const d: number[]|CmpError = [1, 2, 3];
+    const e: string[]|CmpError = ['foo', 'bar'];
+    const f: boolean[]|CmpError = [true, false];
+    expect(collectCmpErrors6(a, b, c, d, e, f)).toEqual([a, b, c, d, e, f]);
   });
 
-  test('retuns a CmpError if one exists in the list', () => {
-    const result = collectCmpErrors([cmpError('error'), 1, 2, 3, 4]);
-    expect(isCmpError(result)).toBeTruthy();
+  test('retuns a CmpError if the first item is a failure', () => {
+    const a: string|CmpError = cmpError('first item failure');
+    const b: number|CmpError = 1;
+    const c: boolean|CmpError = false;
+    const d: number[]|CmpError = [1, 2, 3];
+    const e: string[]|CmpError = ['foo', 'bar'];
+    const f: boolean[]|CmpError = [true, false];
+    expect(isCmpError(collectCmpErrors6(a, b, c, d, e, f))).toBeTruthy();
   });
 
-  test('retuns a CmpError if one exists in the list', () => {
-    const result = collectCmpErrors([1, 2, cmpError('error'), 3, 4]);
-    expect(isCmpError(result)).toBeTruthy();
+  test('retuns a CmpError if the second item is a failure', () => {
+    const a: string|CmpError = 'string';
+    const b: number|CmpError = cmpError('second item failure');
+    const c: boolean|CmpError = false;
+    const d: number[]|CmpError = [1, 2, 3];
+    const e: string[]|CmpError = ['foo', 'bar'];
+    const f: boolean[]|CmpError = [true, false];
+    expect(isCmpError(collectCmpErrors6(a, b, c, d, e, f))).toBeTruthy();
   });
 
-  test('takes the overall CmpError message from a single error', () => {
-    const result = collectCmpErrors([cmpError('test error message'), 1]);
-    if(isCmpError(result)) {
-      expect(result.message).toEqual("test error message");
+  test('retuns a CmpError if the third item is a failure', () => {
+    const a: string|CmpError = 'string';
+    const b: number|CmpError = 1;
+    const c: boolean|CmpError = cmpError('third item failure');
+    const d: number[]|CmpError = [1, 2, 3];
+    const e: string[]|CmpError = ['foo', 'bar'];
+    const f: boolean[]|CmpError = [true, false];
+    expect(isCmpError(collectCmpErrors6(a, b, c, d, e, f))).toBeTruthy();
+  });
+
+  test('retuns a CmpError if the fourth item is a failure', () => {
+    const a: string|CmpError = 'string';
+    const b: number|CmpError = 1;
+    const c: boolean|CmpError = false;
+    const d: number[]|CmpError = cmpError('fourth item failure');
+    const e: string[]|CmpError = ['foo', 'bar'];
+    const f: boolean[]|CmpError = [true, false];
+    expect(isCmpError(collectCmpErrors6(a, b, c, d, e, f))).toBeTruthy();
+  });
+
+  test('retuns a CmpError if the fifth item is a failure', () => {
+    const a: string|CmpError = 'string';
+    const b: number|CmpError = 1;
+    const c: boolean|CmpError = false;
+    const d: number[]|CmpError = [1, 2, 3];
+    const e: string[]|CmpError = cmpError('fifth item failure');
+    const f: boolean[]|CmpError = [true, false];
+    expect(isCmpError(collectCmpErrors6(a, b, c, d, e, f))).toBeTruthy();
+  });
+
+  test('retuns a CmpError if the sixth item is a failure', () => {
+    const a: string|CmpError = 'string';
+    const b: number|CmpError = 1;
+    const c: boolean|CmpError = false;
+    const d: number[]|CmpError = [1, 2, 3];
+    const e: string[]|CmpError = ['foo', 'bar'];
+    const f: boolean[]|CmpError = cmpError('sixth item failure');
+    expect(isCmpError(collectCmpErrors6(a, b, c, d, e, f))).toBeTruthy();
+  });
+
+  test('returns the provided error message for a single failure', () => {
+    const a: string|CmpError = cmpError('test error message');
+    const b: number|CmpError = 1;
+    const c: boolean|CmpError = false;
+    const d: number[]|CmpError = [1, 2, 3];
+    const e: string[]|CmpError = ['foo', 'bar'];
+    const f: boolean[]|CmpError = [true, false];
+    const result = collectCmpErrors6(a, b, c, d, e, f);
+    if (isCmpError(result)) {
+      expect(result.message).toEqual('test error message');
     } else {
       fail('call should have returned a CmpError instance');
     }
   });
 
-  test('takes the overall CmpError message from a single error', () => {
-    const result = collectCmpErrors([cmpError('test error message'), cmpError('another error message'), 1]);
-    if(isCmpError(result)) {
-      expect(result.message).toEqual("test error message, another error message");
+  test('returns concatenated error message for multiple failures', () => {
+    const a: string|CmpError = cmpError('test error message');
+    const b: number|CmpError = cmpError('another error message');
+    const c: boolean|CmpError = false;
+    const d: number[]|CmpError = [1, 2, 3];
+    const e: string[]|CmpError = ['foo', 'bar'];
+    const f: boolean[]|CmpError = [true, false];
+    const result = collectCmpErrors6(a, b, c, d, e, f);
+    if (isCmpError(result)) {
+      expect(result.message)
+          .toEqual('test error message, another error message');
     } else {
       fail('call should have returned a CmpError instance');
     }

--- a/src/errors.spec.ts
+++ b/src/errors.spec.ts
@@ -1,17 +1,36 @@
 /* tslint:disable:no-any */
 import fc from 'fast-check';
+import prettyFormat from 'pretty-format';
 
+import {addCmpExtensions} from './cmpErrorTestExtensions';
 import {CmpError, cmpError, collectCmpErrors, collectCmpErrors4, collectCmpErrors6, isCmpError} from './errors';
+
+addCmpExtensions();
+
+describe('toBeCmpError matcher', () => {
+  test('succesfully matches a cmpError', () => {
+    const value: string|CmpError = cmpError('test error');
+    expect(value).toBeCmpError();
+  });
+
+  test.skip('should fail for a non-CmpError value', () => {
+    expect('abc').toBeCmpError();
+  });
+
+  test.skip('should fail for with an empty CmpError message', () => {
+    expect(cmpError('')).toBeCmpError();
+  });
+});
 
 describe('isCmpError', () => {
   test('returns true for a value that is a cmpError', () => {
     const value: string|CmpError = cmpError('test error');
-    expect(isCmpError(value)).toBeTruthy();
+    expect(isCmpError(value)).toBe(true);
   });
 
   test('returns false for a value that is not a CmpError', () => {
     const value: string|CmpError = 'not an error';
-    expect(isCmpError(value)).toBeFalsy();
+    expect(isCmpError(value)).toBe(false);
   });
 });
 
@@ -29,7 +48,7 @@ describe('collectCmpErrors4', () => {
     const b: number|CmpError = 1;
     const c: boolean|CmpError = false;
     const d: number[]|CmpError = [1, 2, 3];
-    expect(isCmpError(collectCmpErrors4(a, b, c, d))).toBeTruthy();
+    expect(collectCmpErrors4(a, b, c, d)).toBeCmpError();
   });
 
   test('retuns a CmpError if the second item is a failure', () => {
@@ -37,7 +56,7 @@ describe('collectCmpErrors4', () => {
     const b: number|CmpError = cmpError('second item failure');
     const c: boolean|CmpError = false;
     const d: number[]|CmpError = [1, 2, 3];
-    expect(isCmpError(collectCmpErrors4(a, b, c, d))).toBeTruthy();
+    expect(collectCmpErrors4(a, b, c, d)).toBeCmpError();
   });
 
   test('retuns a CmpError if the third item is a failure', () => {
@@ -45,7 +64,7 @@ describe('collectCmpErrors4', () => {
     const b: number|CmpError = 1;
     const c: boolean|CmpError = cmpError('third item failure');
     const d: number[]|CmpError = [1, 2, 3];
-    expect(isCmpError(collectCmpErrors4(a, b, c, d))).toBeTruthy();
+    expect(collectCmpErrors4(a, b, c, d)).toBeCmpError();
   });
 
   test('retuns a CmpError if the fourth item is a failure', () => {
@@ -53,7 +72,7 @@ describe('collectCmpErrors4', () => {
     const b: number|CmpError = 1;
     const c: boolean|CmpError = false;
     const d: number[]|CmpError = cmpError('fourth item failure');
-    expect(isCmpError(collectCmpErrors4(a, b, c, d))).toBeTruthy();
+    expect(collectCmpErrors4(a, b, c, d)).toBeCmpError();
   });
 
   test('returns the provided error message for a single failure', () => {
@@ -62,11 +81,7 @@ describe('collectCmpErrors4', () => {
     const c: boolean|CmpError = false;
     const d: number[]|CmpError = [1, 2, 3];
     const result = collectCmpErrors4(a, b, c, d);
-    if (isCmpError(result)) {
-      expect(result.message).toEqual('test error message');
-    } else {
-      fail('call should have returned a CmpError instance');
-    }
+    expect(result).toBeCmpErrorWithMessage('test error message');
   });
 
   test('returns concatenated error message for multiple failures', () => {
@@ -75,12 +90,8 @@ describe('collectCmpErrors4', () => {
     const c: boolean|CmpError = false;
     const d: number[]|CmpError = [1, 2, 3];
     const result = collectCmpErrors4(a, b, c, d);
-    if (isCmpError(result)) {
-      expect(result.message)
-          .toEqual('test error message, another error message');
-    } else {
-      fail('call should have returned a CmpError instance');
-    }
+    expect(result).toBeCmpErrorWithMessage(
+        'test error message, another error message');
   });
 });
 
@@ -102,7 +113,7 @@ describe('collectCmpErrors6', () => {
     const d: number[]|CmpError = [1, 2, 3];
     const e: string[]|CmpError = ['foo', 'bar'];
     const f: boolean[]|CmpError = [true, false];
-    expect(isCmpError(collectCmpErrors6(a, b, c, d, e, f))).toBeTruthy();
+    expect(collectCmpErrors6(a, b, c, d, e, f)).toBeCmpError();
   });
 
   test('retuns a CmpError if the second item is a failure', () => {
@@ -112,7 +123,7 @@ describe('collectCmpErrors6', () => {
     const d: number[]|CmpError = [1, 2, 3];
     const e: string[]|CmpError = ['foo', 'bar'];
     const f: boolean[]|CmpError = [true, false];
-    expect(isCmpError(collectCmpErrors6(a, b, c, d, e, f))).toBeTruthy();
+    expect(collectCmpErrors6(a, b, c, d, e, f)).toBeCmpError();
   });
 
   test('retuns a CmpError if the third item is a failure', () => {
@@ -122,7 +133,7 @@ describe('collectCmpErrors6', () => {
     const d: number[]|CmpError = [1, 2, 3];
     const e: string[]|CmpError = ['foo', 'bar'];
     const f: boolean[]|CmpError = [true, false];
-    expect(isCmpError(collectCmpErrors6(a, b, c, d, e, f))).toBeTruthy();
+    expect(collectCmpErrors6(a, b, c, d, e, f)).toBeCmpError();
   });
 
   test('retuns a CmpError if the fourth item is a failure', () => {
@@ -132,7 +143,7 @@ describe('collectCmpErrors6', () => {
     const d: number[]|CmpError = cmpError('fourth item failure');
     const e: string[]|CmpError = ['foo', 'bar'];
     const f: boolean[]|CmpError = [true, false];
-    expect(isCmpError(collectCmpErrors6(a, b, c, d, e, f))).toBeTruthy();
+    expect(collectCmpErrors6(a, b, c, d, e, f)).toBeCmpError();
   });
 
   test('retuns a CmpError if the fifth item is a failure', () => {
@@ -142,7 +153,7 @@ describe('collectCmpErrors6', () => {
     const d: number[]|CmpError = [1, 2, 3];
     const e: string[]|CmpError = cmpError('fifth item failure');
     const f: boolean[]|CmpError = [true, false];
-    expect(isCmpError(collectCmpErrors6(a, b, c, d, e, f))).toBeTruthy();
+    expect(collectCmpErrors6(a, b, c, d, e, f)).toBeCmpError();
   });
 
   test('retuns a CmpError if the sixth item is a failure', () => {
@@ -152,7 +163,7 @@ describe('collectCmpErrors6', () => {
     const d: number[]|CmpError = [1, 2, 3];
     const e: string[]|CmpError = ['foo', 'bar'];
     const f: boolean[]|CmpError = cmpError('sixth item failure');
-    expect(isCmpError(collectCmpErrors6(a, b, c, d, e, f))).toBeTruthy();
+    expect(collectCmpErrors6(a, b, c, d, e, f)).toBeCmpError();
   });
 
   test('returns the provided error message for a single failure', () => {
@@ -163,11 +174,7 @@ describe('collectCmpErrors6', () => {
     const e: string[]|CmpError = ['foo', 'bar'];
     const f: boolean[]|CmpError = [true, false];
     const result = collectCmpErrors6(a, b, c, d, e, f);
-    if (isCmpError(result)) {
-      expect(result.message).toEqual('test error message');
-    } else {
-      fail('call should have returned a CmpError instance');
-    }
+    expect(result).toBeCmpErrorWithMessage('test error message');
   });
 
   test('returns concatenated error message for multiple failures', () => {
@@ -178,12 +185,8 @@ describe('collectCmpErrors6', () => {
     const e: string[]|CmpError = ['foo', 'bar'];
     const f: boolean[]|CmpError = [true, false];
     const result = collectCmpErrors6(a, b, c, d, e, f);
-    if (isCmpError(result)) {
-      expect(result.message)
-          .toEqual('test error message, another error message');
-    } else {
-      fail('call should have returned a CmpError instance');
-    }
+    expect(result).toBeCmpErrorWithMessage(
+        'test error message, another error message');
   });
 });
 
@@ -197,31 +200,23 @@ describe('collectCmpErrors', () => {
 
   test('retuns a CmpError if one exists in the list', () => {
     const result = collectCmpErrors([cmpError('error'), 1, 2, 3, 4]);
-    expect(isCmpError(result)).toBeTruthy();
+    expect(result).toBeCmpError();
   });
 
   test('retuns a CmpError if one exists in the list', () => {
     const result = collectCmpErrors([1, 2, cmpError('error'), 3, 4]);
-    expect(isCmpError(result)).toBeTruthy();
+    expect(result).toBeCmpError();
   });
 
   test('takes the overall CmpError message from a single error', () => {
     const result = collectCmpErrors([cmpError('test error message'), 1]);
-    if (isCmpError(result)) {
-      expect(result.message).toEqual('test error message');
-    } else {
-      fail('call should have returned a CmpError instance');
-    }
+    expect(result).toBeCmpErrorWithMessage('test error message');
   });
 
   test('takes the overall CmpError message from a single error', () => {
     const result = collectCmpErrors(
         [cmpError('test error message'), cmpError('another error message'), 1]);
-    if (isCmpError(result)) {
-      expect(result.message)
-          .toEqual('test error message, another error message');
-    } else {
-      fail('call should have returned a CmpError instance');
-    }
+    expect(result).toBeCmpErrorWithMessage(
+        'test error message, another error message');
   });
 });

--- a/src/errors.spec.ts
+++ b/src/errors.spec.ts
@@ -1,0 +1,121 @@
+/* tslint:disable:no-any */
+import fc from 'fast-check';
+
+import {CmpError, cmpError, isCmpError, collectCmpErrors, collectCmpErrors4} from './errors';
+
+describe('isCmpError', () => {
+  test('returns true for a value that is a cmpError', () => {
+    const value: string|CmpError = cmpError('test error');
+    expect(isCmpError(value)).toBeTruthy();
+  });
+
+  test('returns false for a value that is not a CmpError', () => {
+    const value: string|CmpError = "not an error";
+    expect(isCmpError(value)).toBeFalsy();
+  });
+});
+
+describe('collectCmpErrors4', () => {
+  test('retuns the four successful values if all four succeeded', () => {
+    const a: string|CmpError = "string";
+    const b: number|CmpError = 1;
+    const c: boolean|CmpError = false;
+    const d: Array<number>|CmpError = [1, 2, 3];
+    expect(collectCmpErrors4(a, b, c, d)).toEqual([a, b, c, d]);
+  });
+
+  test('retuns a CmpError if the first item is a failure', () => {
+    const a: string|CmpError = cmpError('first item failure');
+    const b: number|CmpError = 1;
+    const c: boolean|CmpError = false;
+    const d: Array<number>|CmpError = [1, 2, 3];
+    expect(isCmpError(collectCmpErrors4(a, b, c, d))).toBeTruthy();
+  });
+
+  test('retuns a CmpError if the second item is a failure', () => {
+    const a: string|CmpError = "string";
+    const b: number|CmpError = cmpError('second item failure');
+    const c: boolean|CmpError = false;
+    const d: Array<number>|CmpError = [1, 2, 3];
+    expect(isCmpError(collectCmpErrors4(a, b, c, d))).toBeTruthy();
+  });
+
+  test('retuns a CmpError if the third item is a failure', () => {
+    const a: string|CmpError = "string";
+    const b: number|CmpError = 1;
+    const c: boolean|CmpError = cmpError('third item failure');
+    const d: Array<number>|CmpError = [1, 2, 3];
+    expect(isCmpError(collectCmpErrors4(a, b, c, d))).toBeTruthy();
+  });
+
+  test('retuns a CmpError if the fourth item is a failure', () => {
+    const a: string|CmpError = "string";
+    const b: number|CmpError = 1;
+    const c: boolean|CmpError = false;
+    const d: Array<number>|CmpError = cmpError('fourth item failure');
+    expect(isCmpError(collectCmpErrors4(a, b, c, d))).toBeTruthy();
+  });
+
+  test('returns the provided error message for a single failure', () => {
+    const a: string|CmpError = cmpError('test error message');
+    const b: number|CmpError = 1;
+    const c: boolean|CmpError = false;
+    const d: Array<number>|CmpError = [1, 2, 3];
+    const result = collectCmpErrors4(a, b, c, d);
+    if(isCmpError(result)) {
+      expect(result.message).toEqual("test error message");
+    } else {
+      fail('call should have returned a CmpError instance');
+    }
+  });
+
+  test('returns concatenated error message for multiple failures', () => {
+    const a: string|CmpError = cmpError('test error message');
+    const b: number|CmpError = cmpError('another error message');
+    const c: boolean|CmpError = false;
+    const d: Array<number>|CmpError = [1, 2, 3];
+    const result = collectCmpErrors4(a, b, c, d);
+    if(isCmpError(result)) {
+      expect(result.message).toEqual("test error message, another error message");
+    } else {
+      fail('call should have returned a CmpError instance');
+    }
+  });
+});
+
+describe('collectCmpErrors', () => {
+  test('retuns the successful values if they all succeeded', () => {
+    const generator = fc.array(fc.integer());
+    fc.assert(fc.property(generator, (arr) => {
+      expect(collectCmpErrors(arr)).toEqual(arr);
+    }));
+  });
+
+  test('retuns a CmpError if one exists in the list', () => {
+    const result = collectCmpErrors([cmpError('error'), 1, 2, 3, 4]);
+    expect(isCmpError(result)).toBeTruthy();
+  });
+
+  test('retuns a CmpError if one exists in the list', () => {
+    const result = collectCmpErrors([1, 2, cmpError('error'), 3, 4]);
+    expect(isCmpError(result)).toBeTruthy();
+  });
+
+  test('takes the overall CmpError message from a single error', () => {
+    const result = collectCmpErrors([cmpError('test error message'), 1]);
+    if(isCmpError(result)) {
+      expect(result.message).toEqual("test error message");
+    } else {
+      fail('call should have returned a CmpError instance');
+    }
+  });
+
+  test('takes the overall CmpError message from a single error', () => {
+    const result = collectCmpErrors([cmpError('test error message'), cmpError('another error message'), 1]);
+    if(isCmpError(result)) {
+      expect(result.message).toEqual("test error message, another error message");
+    } else {
+      fail('call should have returned a CmpError instance');
+    }
+  });
+});

--- a/src/errors.spec.ts
+++ b/src/errors.spec.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-any */
 import fc from 'fast-check';
 
-import {CmpError, cmpError, collectCmpErrors4, collectCmpErrors6, isCmpError} from './errors';
+import {CmpError, cmpError, collectCmpErrors, collectCmpErrors4, collectCmpErrors6, isCmpError} from './errors';
 
 describe('isCmpError', () => {
   test('returns true for a value that is a cmpError', () => {
@@ -178,6 +178,45 @@ describe('collectCmpErrors6', () => {
     const e: string[]|CmpError = ['foo', 'bar'];
     const f: boolean[]|CmpError = [true, false];
     const result = collectCmpErrors6(a, b, c, d, e, f);
+    if (isCmpError(result)) {
+      expect(result.message)
+          .toEqual('test error message, another error message');
+    } else {
+      fail('call should have returned a CmpError instance');
+    }
+  });
+});
+
+describe('collectCmpErrors', () => {
+  test('retuns the successful values if they all succeeded', () => {
+    const generator = fc.array(fc.integer());
+    fc.assert(fc.property(generator, (arr) => {
+      expect(collectCmpErrors(arr)).toEqual(arr);
+    }));
+  });
+
+  test('retuns a CmpError if one exists in the list', () => {
+    const result = collectCmpErrors([cmpError('error'), 1, 2, 3, 4]);
+    expect(isCmpError(result)).toBeTruthy();
+  });
+
+  test('retuns a CmpError if one exists in the list', () => {
+    const result = collectCmpErrors([1, 2, cmpError('error'), 3, 4]);
+    expect(isCmpError(result)).toBeTruthy();
+  });
+
+  test('takes the overall CmpError message from a single error', () => {
+    const result = collectCmpErrors([cmpError('test error message'), 1]);
+    if (isCmpError(result)) {
+      expect(result.message).toEqual('test error message');
+    } else {
+      fail('call should have returned a CmpError instance');
+    }
+  });
+
+  test('takes the overall CmpError message from a single error', () => {
+    const result = collectCmpErrors(
+        [cmpError('test error message'), cmpError('another error message'), 1]);
     if (isCmpError(result)) {
       expect(result.message)
           .toEqual('test error message, another error message');

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -37,4 +37,22 @@ function collectCmpErrors6<A, B, C, D, E, F>(
   }
 }
 
-export {cmpError, CmpError, isCmpError, collectCmpErrors6, collectCmpErrors4};
+function collectCmpErrors<T>(values: Array<CmpError|T>): CmpError|T[] {
+  if (values.some(isCmpError)) {
+    const combinedMessage =
+        values.filter(isCmpError).map((err) => err.message).join(', ');
+    return cmpError(combinedMessage);
+  } else {
+    // no errors exist, so we know that this is `T[]`
+    return values as T[];
+  }
+}
+
+export {
+  cmpError,
+  CmpError,
+  isCmpError,
+  collectCmpErrors,
+  collectCmpErrors4,
+  collectCmpErrors6
+};

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -23,14 +23,18 @@ function collectCmpErrors4<A, B, C, D>(
   }
 }
 
-function collectCmpErrors<T>(values: Array<CmpError|T>): CmpError|T[] {
-  if (values.some(isCmpError)) {
-    const combinedMessage = values.filter(isCmpError).map((err) => err.message).join(', ');
-    return cmpError(combinedMessage);
+function collectCmpErrors6<A, B, C, D, E, F>(
+    a: CmpError|A, b: CmpError|B, c: CmpError|C, d: CmpError|D, e: CmpError|E,
+    f: CmpError|F): CmpError|[A, B, C, D, E, F] {
+  if (isCmpError(a) || isCmpError(b) || isCmpError(c) || isCmpError(d) ||
+      isCmpError(e) || isCmpError(f)) {
+    const combinedError =
+        [a, b, c, d].filter(isCmpError).map((err) => err.message).join(', ');
+    return cmpError(combinedError);
   } else {
-    // no errors exist, so we know that this is `T[]`
-    return values as T[];
+    // no errors exist so we know that this is `[A, B, C, D]`
+    return [a as A, b as B, c as C, d as D, e as E, f as F];
   }
 }
 
-export {cmpError, CmpError, isCmpError, collectCmpErrors, collectCmpErrors4};
+export {cmpError, CmpError, isCmpError, collectCmpErrors6, collectCmpErrors4};

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,36 @@
+interface CmpError {
+  message: string;
+}
+
+const cmpError = (message: string): CmpError => {
+  return {message};
+};
+
+function isCmpError<T>(value: CmpError|T): value is CmpError {
+  return (value as CmpError).message !== undefined;
+}
+
+function collectCmpErrors4<A, B, C, D>(
+    a: CmpError|A, b: CmpError|B, c: CmpError|C,
+    d: CmpError|D): CmpError|[A, B, C, D] {
+  if (isCmpError(a) || isCmpError(b) || isCmpError(c) || isCmpError(d)) {
+    const combinedError =
+        [a, b, c, d].filter(isCmpError).map((err) => err.message).join(', ');
+    return cmpError(combinedError);
+  } else {
+    // no errors exist so we know that this is `[A, B, C, D]`
+    return [a as A, b as B, c as C, d as D];
+  }
+}
+
+function collectCmpErrors<T>(values: Array<CmpError|T>): CmpError|T[] {
+  if (values.some(isCmpError)) {
+    const combinedMessage = values.filter(isCmpError).map((err) => err.message).join(', ');
+    return cmpError(combinedMessage);
+  } else {
+    // no errors exist, so we know that this is `T[]`
+    return values as T[];
+  }
+}
+
+export {cmpError, CmpError, isCmpError, collectCmpErrors, collectCmpErrors4};

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -28,8 +28,10 @@ function collectCmpErrors6<A, B, C, D, E, F>(
     f: CmpError|F): CmpError|[A, B, C, D, E, F] {
   if (isCmpError(a) || isCmpError(b) || isCmpError(c) || isCmpError(d) ||
       isCmpError(e) || isCmpError(f)) {
-    const combinedError =
-        [a, b, c, d].filter(isCmpError).map((err) => err.message).join(', ');
+    const combinedError = [a, b, c, d, e, f]
+                              .filter(isCmpError)
+                              .map((err) => err.message)
+                              .join(', ');
     return cmpError(combinedError);
   } else {
     // no errors exist so we know that this is `[A, B, C, D]`

--- a/src/model.spec.ts
+++ b/src/model.spec.ts
@@ -7,11 +7,11 @@ import {_, parseJson} from './model';
 
 const {
   isNumber,
-  isValidSourceType,
-  isValidPurposeType,
-  isValidConsentString,
-  isValidPurposes,
-  isValidBrowserId,
+  validateSourceType,
+  validatePurposeType,
+  validateConsentString,
+  validatePurposes,
+  validateBrowserId,
   sourceTypes,
   purposeTypes,
   isNonEmpty
@@ -45,8 +45,8 @@ describe('parseJson', () => {
   });
 
   test('Should reject random objects', () => {
-    fc.assert(
-        fc.property(fc.json(), (jsonString: string) => isCmpError(parseJson(jsonString))));
+    fc.assert(fc.property(
+        fc.json(), (jsonString: string) => isCmpError(parseJson(jsonString))));
   });
 
   describe('iab key', () => {
@@ -56,7 +56,8 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {iab: invalidType});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
+            .toBeTruthy();
       }));
     });
   });
@@ -78,7 +79,8 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidVersions, (invalidVersion: string) => {
         const invalidObject =
             Object.assign({}, validObject, {version: invalidVersion});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
+            .toBeTruthy();
       }));
     });
 
@@ -88,7 +90,8 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {version: invalidType});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
+            .toBeTruthy();
       }));
     });
   });
@@ -109,7 +112,8 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {time: invalidType});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
+            .toBeTruthy();
       }));
     });
   });
@@ -130,7 +134,8 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidSourceTypes, (invalidSourceType: string) => {
         const invalidObject =
             Object.assign({}, validObject, {source: invalidSourceType});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
+            .toBeTruthy();
       }));
     });
 
@@ -140,15 +145,17 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {source: invalidType});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
+            .toBeTruthy();
       }));
     });
   });
 
   describe('purposes key', () => {
-    test('Should reject an empty object', () => {
+    test('Should reject an empty purposes object', () => {
       const newValidObject = Object.assign({}, validObject, {purposes: {}});
-      expect(isCmpError(parseJson(JSON.stringify(newValidObject)))).toBeTruthy();
+      expect(isCmpError(parseJson(JSON.stringify(newValidObject))))
+          .toBeTruthy();
     });
 
     test('Should accept valid purposes', () => {
@@ -163,7 +170,8 @@ describe('parseJson', () => {
           (invalidPurpose: string, randomBoolean: boolean) => {
             const invalidObject = Object.assign(
                 {}, validObject, {purposes: {invalidPurpose: randomBoolean}});
-            expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
+            expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
+                .toBeTruthy();
           }));
     });
 
@@ -173,7 +181,8 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {purposes: invalidType});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
+            .toBeTruthy();
       }));
     });
 
@@ -187,7 +196,8 @@ describe('parseJson', () => {
           (validPurposeKey: string, invalidType: any) => {
             const invalidObject = Object.assign(
                 {}, validObject, {purposes: {[validPurposeKey]: invalidType}});
-            expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
+            expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
+                .toBeTruthy();
           }));
     });
 
@@ -200,7 +210,8 @@ describe('parseJson', () => {
             removeProperty(purposeKey, validObject.purposes);
         const invalidObject =
             Object.assign({}, validObject, {purposes: invalidPurposes});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
+            .toBeTruthy();
       });
     });
   });
@@ -208,7 +219,8 @@ describe('parseJson', () => {
   describe('browserId key', () => {
     test('Should not acccept an empty string', () => {
       const newInvalidObject = Object.assign({}, validObject, {browserId: ''});
-      expect(isCmpError(parseJson(JSON.stringify(newInvalidObject)))).toBeTruthy();
+      expect(isCmpError(parseJson(JSON.stringify(newInvalidObject))))
+          .toBeTruthy();
     });
     test('Should accept any non-empty string', () => {
       const nonEmptyString = fc.string(1, 40).filter(s => s.trim().length > 0);
@@ -226,7 +238,8 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {browserId: invalidType});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
+            .toBeTruthy();
       }));
     });
   });
@@ -264,29 +277,33 @@ describe('isNonEmpty', () => {
 
 describe('isValidSourceType', () => {
   test('should only allow valid source types', () => {
-    expect(sourceTypes.every(isValidSourceType)).toBe(true);
+    expect(isCmpError(sourceTypes.every(validateSourceType))).toBeFalsy();
   });
 
   test('should not allow an empty string', () => {
-    expect(isValidSourceType('')).toBe(false);
+    expect(isCmpError(validateSourceType(''))).toBeTruthy();
   });
 
   test('should not accept random strings', () => {
     fc.assert(fc.property(
         fc.string(),
-        (randomString: string) => !isValidSourceType(randomString)));
+        (randomString: string) =>
+            isCmpError(validateSourceType(randomString))));
   });
 });
 
 describe('isValidPurposeType', () => {
   test('should only allow valid purpose types', () => {
-    expect(purposeTypes.every(isValidPurposeType)).toBe(true);
+    expect(purposeTypes.every(
+               (purposeType) => isCmpError(validatePurposeType(purposeType))))
+        .toBe(false);
   });
 
   test('should not accept random strings', () => {
     fc.assert(fc.property(
         fc.string(),
-        (randomString: string) => !isValidPurposeType(randomString)));
+        (randomString: string) =>
+            isCmpError(validatePurposeType(randomString))));
   });
 });
 
@@ -297,14 +314,15 @@ describe('isValidConsentString', () => {
     const validConsentStrings = ['BOkhG-BOkhG-BAAABAENAAAAAAAAoAA'];
     validConsentStrings.forEach(
         consentString =>
-            expect(isValidConsentString(consentString)).toBe(true));
+            expect(isCmpError(validateConsentString(consentString)))
+                .toBeFalsy());
   });
 
   test('Should not accept random IAB consent strings', () => {
     fc.assert(fc.property(
         fc.unicodeString(),
         (randomUnicodeString: string) =>
-            !isValidConsentString(randomUnicodeString)));
+            isCmpError(validateConsentString(randomUnicodeString))));
   });
 });
 
@@ -318,7 +336,7 @@ describe('isValidPurposes', () => {
   const purposesArbitrary = fc.constantFrom(...purposeTypes);
 
   test('accepts complete list of purposes', () => {
-    expect(isValidPurposes(validPurposes)).toBeTruthy();
+    expect(validatePurposes(validPurposes)).toEqual(validPurposes);
   });
 
   test('Should not accept random strings in keys', () => {
@@ -327,9 +345,10 @@ describe('isValidPurposes', () => {
                       fc.string(), [fc.boolean()], 1, 5, false, false))
             .filter(o => Object.keys(o).length > 0);
 
-    fc.assert(fc.property(
-        invalidKeysPurposesListArbitrary,
-        (invalidPurposes) => !isValidPurposes(invalidPurposes)));
+    fc.assert(
+        fc.property(invalidKeysPurposesListArbitrary, (invalidPurposes) => {
+          expect(isCmpError(validatePurposes(invalidPurposes))).toBeTruthy();
+        }));
   });
 
   test('does not accept an object missing required purposes', () => {
@@ -338,20 +357,22 @@ describe('isValidPurposes', () => {
 
     purposeTypes.forEach((purposeKey) => {
       const invalidPurposes = removeProperty(purposeKey, validPurposes);
-      expect(isCmpError(parseJson(JSON.stringify(invalidPurposes)))).toBeTruthy();
+      expect(isCmpError(parseJson(JSON.stringify(invalidPurposes))))
+          .toBeTruthy();
     });
   });
 });
 
 describe('isValidBrowserId', () => {
   test('Should not accept an empty string', () => {
-    expect(isValidBrowserId('')).toBe(false);
+    expect(isCmpError(validateBrowserId(''))).toBeTruthy();
   });
 
   test('Should accept any non-empty string', () => {
     const nonEmptyString = fc.string(1, 40).filter(s => s.trim().length > 0);
     fc.assert(fc.property(
         nonEmptyString,
-        (nonEmptyString: string) => isValidBrowserId(nonEmptyString)));
+        (nonEmptyString: string) =>
+            expect(isCmpError(validateBrowserId(nonEmptyString))).toBeFalsy()));
   });
 });

--- a/src/model.spec.ts
+++ b/src/model.spec.ts
@@ -2,8 +2,11 @@
 /* tslint:disable:no-any */
 import fc from 'fast-check';
 
+import {addCmpExtensions} from './cmpErrorTestExtensions';
 import {isCmpError} from './errors';
 import {_, parseJson} from './model';
+
+addCmpExtensions();
 
 const {
   isNumber,
@@ -33,11 +36,11 @@ describe('parseJson', () => {
   };
 
   test('Should not parse an empty string', () => {
-    expect(isCmpError(parseJson(''))).toBeTruthy();
+    expect(parseJson('')).toBeCmpError();
   });
 
   test('Should not parse an empty object in a string', () => {
-    expect(isCmpError(parseJson('{}'))).toBeTruthy();
+    expect(parseJson('{}')).toBeCmpError();
   });
 
   test('Should parse an object with all keys', () => {
@@ -45,8 +48,9 @@ describe('parseJson', () => {
   });
 
   test('Should reject random objects', () => {
-    fc.assert(fc.property(
-        fc.json(), (jsonString: string) => isCmpError(parseJson(jsonString))));
+    fc.assert(fc.property(fc.json(), (jsonString: string) => {
+      expect(parseJson(jsonString)).toBeCmpError();
+    }));
   });
 
   describe('iab key', () => {
@@ -56,8 +60,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {iab: invalidType});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
-            .toBeTruthy();
+        expect(parseJson(JSON.stringify(invalidObject))).toBeCmpError();
       }));
     });
   });
@@ -79,8 +82,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidVersions, (invalidVersion: string) => {
         const invalidObject =
             Object.assign({}, validObject, {version: invalidVersion});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
-            .toBeTruthy();
+        expect(parseJson(JSON.stringify(invalidObject))).toBeCmpError();
       }));
     });
 
@@ -90,8 +92,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {version: invalidType});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
-            .toBeTruthy();
+        expect(parseJson(JSON.stringify(invalidObject))).toBeCmpError();
       }));
     });
   });
@@ -112,8 +113,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {time: invalidType});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
-            .toBeTruthy();
+        expect(parseJson(JSON.stringify(invalidObject))).toBeCmpError();
       }));
     });
   });
@@ -134,8 +134,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidSourceTypes, (invalidSourceType: string) => {
         const invalidObject =
             Object.assign({}, validObject, {source: invalidSourceType});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
-            .toBeTruthy();
+        expect(parseJson(JSON.stringify(invalidObject))).toBeCmpError();
       }));
     });
 
@@ -145,8 +144,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {source: invalidType});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
-            .toBeTruthy();
+        expect(parseJson(JSON.stringify(invalidObject))).toBeCmpError();
       }));
     });
   });
@@ -154,8 +152,7 @@ describe('parseJson', () => {
   describe('purposes key', () => {
     test('Should reject an empty purposes object', () => {
       const newValidObject = Object.assign({}, validObject, {purposes: {}});
-      expect(isCmpError(parseJson(JSON.stringify(newValidObject))))
-          .toBeTruthy();
+      expect(parseJson(JSON.stringify(newValidObject))).toBeCmpError();
     });
 
     test('Should accept valid purposes', () => {
@@ -170,8 +167,7 @@ describe('parseJson', () => {
           (invalidPurpose: string, randomBoolean: boolean) => {
             const invalidObject = Object.assign(
                 {}, validObject, {purposes: {invalidPurpose: randomBoolean}});
-            expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
-                .toBeTruthy();
+            expect(parseJson(JSON.stringify(invalidObject))).toBeCmpError();
           }));
     });
 
@@ -181,8 +177,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {purposes: invalidType});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
-            .toBeTruthy();
+        expect(parseJson(JSON.stringify(invalidObject))).toBeCmpError();
       }));
     });
 
@@ -196,8 +191,7 @@ describe('parseJson', () => {
           (validPurposeKey: string, invalidType: any) => {
             const invalidObject = Object.assign(
                 {}, validObject, {purposes: {[validPurposeKey]: invalidType}});
-            expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
-                .toBeTruthy();
+            expect(parseJson(JSON.stringify(invalidObject))).toBeCmpError();
           }));
     });
 
@@ -210,8 +204,7 @@ describe('parseJson', () => {
             removeProperty(purposeKey, validObject.purposes);
         const invalidObject =
             Object.assign({}, validObject, {purposes: invalidPurposes});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
-            .toBeTruthy();
+        expect(parseJson(JSON.stringify(invalidObject))).toBeCmpError();
       });
     });
   });
@@ -219,8 +212,7 @@ describe('parseJson', () => {
   describe('browserId key', () => {
     test('Should not acccept an empty string', () => {
       const newInvalidObject = Object.assign({}, validObject, {browserId: ''});
-      expect(isCmpError(parseJson(JSON.stringify(newInvalidObject))))
-          .toBeTruthy();
+      expect(parseJson(JSON.stringify(newInvalidObject))).toBeCmpError();
     });
     test('Should accept any non-empty string', () => {
       const nonEmptyString = fc.string(1, 40).filter(s => s.trim().length > 0);
@@ -238,8 +230,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {browserId: invalidType});
-        expect(isCmpError(parseJson(JSON.stringify(invalidObject))))
-            .toBeTruthy();
+        expect(parseJson(JSON.stringify(invalidObject))).toBeCmpError();
       }));
     });
   });
@@ -277,37 +268,35 @@ describe('isNonEmpty', () => {
 
 describe('validateSourceType', () => {
   test('should only allow valid source types', () => {
-    expect(isCmpError(sourceTypes.every(validateSourceType))).toBeFalsy();
+    expect(sourceTypes.every(validateSourceType)).toNotBeCmpError();
   });
 
   test('should not allow an empty string', () => {
-    expect(isCmpError(validateSourceType(''))).toBeTruthy();
+    expect(validateSourceType('')).toBeCmpError();
   });
 
   test('should not accept random strings', () => {
-    fc.assert(fc.property(
-        fc.string(),
-        (randomString: string) =>
-            isCmpError(validateSourceType(randomString))));
+    fc.assert(fc.property(fc.string(), (randomString: string) => {
+      expect(validateSourceType(randomString)).toBeCmpError();
+    }));
   });
 });
 
 describe('validatePurposeType', () => {
   test('should only allow valid purpose types', () => {
-    expect(purposeTypes.every(
-               (purposeType) => isCmpError(validatePurposeType(purposeType))))
-        .toBe(false);
+    expect(
+        purposeTypes.every((purposeType) => validatePurposeType(purposeType)))
+        .toNotBeCmpError();
   });
 
   test('should not accept random strings', () => {
-    fc.assert(fc.property(
-        fc.string(),
-        (randomString: string) =>
-            isCmpError(validatePurposeType(randomString))));
+    fc.assert(fc.property(fc.string(), (randomString: string) => {
+      expect(validatePurposeType(randomString)).toBeCmpError();
+    }));
   });
 
   test('should not accept an invalid type as its argument', () => {
-    expect(isCmpError(validatePurposeType(123))).toBeTruthy();
+    expect(validatePurposeType(123)).toBeCmpError();
   });
 });
 
@@ -318,19 +307,17 @@ describe('validateConsentString', () => {
     const validConsentStrings = ['BOkhG-BOkhG-BAAABAENAAAAAAAAoAA'];
     validConsentStrings.forEach(
         consentString =>
-            expect(isCmpError(validateConsentString(consentString)))
-                .toBeFalsy());
+            expect(validateConsentString(consentString)).toNotBeCmpError());
   });
 
   test('Should not accept random IAB consent strings', () => {
-    fc.assert(fc.property(
-        fc.unicodeString(),
-        (randomUnicodeString: string) =>
-            isCmpError(validateConsentString(randomUnicodeString))));
+    fc.assert(fc.property(fc.unicodeString(), (randomUnicodeString: string) => {
+      expect(validateConsentString(randomUnicodeString)).toBeCmpError();
+    }));
   });
 
   test('should not accept an invalid type as its argument', () => {
-    expect(isCmpError(validateConsentString(123))).toBeTruthy();
+    expect(validateConsentString(123)).toBeCmpError();
   });
 });
 
@@ -355,7 +342,7 @@ describe('validatePurposes', () => {
 
     fc.assert(
         fc.property(invalidKeysPurposesListArbitrary, (invalidPurposes) => {
-          expect(isCmpError(validatePurposes(invalidPurposes))).toBeTruthy();
+          expect(validatePurposes(invalidPurposes)).toBeCmpError();
         }));
   });
 
@@ -365,7 +352,7 @@ describe('validatePurposes', () => {
 
     purposeTypes.forEach((purposeKey) => {
       const invalidPurposes = removeProperty(purposeKey, validPurposes);
-      expect(isCmpError(validatePurposes(invalidPurposes))).toBeTruthy();
+      expect(validatePurposes(invalidPurposes)).toBeCmpError();
     });
   });
 
@@ -383,14 +370,13 @@ describe('validatePurposes', () => {
 
 describe('validateBrowserId', () => {
   test('Should not accept an empty string', () => {
-    expect(isCmpError(validateBrowserId(''))).toBeTruthy();
+    expect(validateBrowserId('')).toBeCmpError();
   });
 
   test('Should accept any non-empty string', () => {
     const nonEmptyString = fc.string(1, 40).filter(s => s.trim().length > 0);
-    fc.assert(fc.property(
-        nonEmptyString,
-        (nonEmptyString: string) =>
-            expect(isCmpError(validateBrowserId(nonEmptyString))).toBeFalsy()));
+    fc.assert(fc.property(nonEmptyString, (nonEmptyString: string) => {
+      expect(validateBrowserId(nonEmptyString)).toNotBeCmpError();
+    }));
   });
 });

--- a/src/model.spec.ts
+++ b/src/model.spec.ts
@@ -30,7 +30,7 @@ describe('parseJson', () => {
       'essential': false,
       'performance': false,
       'functionality': false,
-      'presonalisedAdvertising': false
+      'personalisedAdvertising': false
     },
     browserId: 'abc123'
   };
@@ -326,7 +326,7 @@ describe('validatePurposes', () => {
     'essential': false,
     'performance': false,
     'functionality': false,
-    'presonalisedAdvertising': false
+    'personalisedAdvertising': false
   };
   const purposesArbitrary = fc.constantFrom(...purposeTypes);
 

--- a/src/model.spec.ts
+++ b/src/model.spec.ts
@@ -275,7 +275,7 @@ describe('isNonEmpty', () => {
   });
 });
 
-describe('isValidSourceType', () => {
+describe('validateSourceType', () => {
   test('should only allow valid source types', () => {
     expect(isCmpError(sourceTypes.every(validateSourceType))).toBeFalsy();
   });
@@ -292,7 +292,7 @@ describe('isValidSourceType', () => {
   });
 });
 
-describe('isValidPurposeType', () => {
+describe('validatePurposeType', () => {
   test('should only allow valid purpose types', () => {
     expect(purposeTypes.every(
                (purposeType) => isCmpError(validatePurposeType(purposeType))))
@@ -305,9 +305,13 @@ describe('isValidPurposeType', () => {
         (randomString: string) =>
             isCmpError(validatePurposeType(randomString))));
   });
+
+  test('should not accept an invalid type as its argument', () => {
+    expect(isCmpError(validatePurposeType(123))).toBeTruthy();
+  });
 });
 
-describe('isValidConsentString', () => {
+describe('validateConsentString', () => {
   // Consent string tool
   // http://gdpr-demo.labs.quantcast.com/user-examples/cookie-workshop.html
   test('Should accept IAB consent strings', () => {
@@ -324,9 +328,13 @@ describe('isValidConsentString', () => {
         (randomUnicodeString: string) =>
             isCmpError(validateConsentString(randomUnicodeString))));
   });
+
+  test('should not accept an invalid type as its argument', () => {
+    expect(isCmpError(validateConsentString(123))).toBeTruthy();
+  });
 });
 
-describe('isValidPurposes', () => {
+describe('validatePurposes', () => {
   const validPurposes = {
     'essential': false,
     'performance': false,
@@ -357,13 +365,23 @@ describe('isValidPurposes', () => {
 
     purposeTypes.forEach((purposeKey) => {
       const invalidPurposes = removeProperty(purposeKey, validPurposes);
-      expect(isCmpError(parseJson(JSON.stringify(invalidPurposes))))
-          .toBeTruthy();
+      expect(isCmpError(validatePurposes(invalidPurposes))).toBeTruthy();
     });
+  });
+
+  test('fails with a helpful message for purpose with wrong type', () => {
+    const invalidPurposes =
+        Object.assign({}, validPurposes, {'essential': 123});
+    const result = validatePurposes(invalidPurposes);
+    if (isCmpError(result)) {
+      expect(result.message).toContain('essential');
+    } else {
+      fail('call should have failed beacuse essential has the wrong type');
+    }
   });
 });
 
-describe('isValidBrowserId', () => {
+describe('validateBrowserId', () => {
   test('Should not accept an empty string', () => {
     expect(isCmpError(validateBrowserId(''))).toBeTruthy();
   });

--- a/src/model.spec.ts
+++ b/src/model.spec.ts
@@ -2,6 +2,7 @@
 /* tslint:disable:no-any */
 import fc from 'fast-check';
 
+import {isCmpError} from './errors';
 import {_, parseJson} from './model';
 
 const {
@@ -32,11 +33,11 @@ describe('parseJson', () => {
   };
 
   test('Should not parse an empty string', () => {
-    expect(parseJson('')).toBeNull();
+    expect(isCmpError(parseJson(''))).toBeTruthy();
   });
 
   test('Should not parse an empty object in a string', () => {
-    expect(parseJson('{}')).toBeNull();
+    expect(isCmpError(parseJson('{}'))).toBeTruthy();
   });
 
   test('Should parse an object with all keys', () => {
@@ -45,7 +46,7 @@ describe('parseJson', () => {
 
   test('Should reject random objects', () => {
     fc.assert(
-        fc.property(fc.json(), (jsonString: string) => !parseJson(jsonString)));
+        fc.property(fc.json(), (jsonString: string) => isCmpError(parseJson(jsonString))));
   });
 
   describe('iab key', () => {
@@ -55,7 +56,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {iab: invalidType});
-        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
       }));
     });
   });
@@ -77,7 +78,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidVersions, (invalidVersion: string) => {
         const invalidObject =
             Object.assign({}, validObject, {version: invalidVersion});
-        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
       }));
     });
 
@@ -87,7 +88,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {version: invalidType});
-        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
       }));
     });
   });
@@ -108,7 +109,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {time: invalidType});
-        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
       }));
     });
   });
@@ -129,7 +130,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidSourceTypes, (invalidSourceType: string) => {
         const invalidObject =
             Object.assign({}, validObject, {source: invalidSourceType});
-        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
       }));
     });
 
@@ -139,7 +140,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {source: invalidType});
-        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
       }));
     });
   });
@@ -147,7 +148,7 @@ describe('parseJson', () => {
   describe('purposes key', () => {
     test('Should reject an empty object', () => {
       const newValidObject = Object.assign({}, validObject, {purposes: {}});
-      expect(parseJson(JSON.stringify(newValidObject))).toBeFalsy();
+      expect(isCmpError(parseJson(JSON.stringify(newValidObject)))).toBeTruthy();
     });
 
     test('Should accept valid purposes', () => {
@@ -162,7 +163,7 @@ describe('parseJson', () => {
           (invalidPurpose: string, randomBoolean: boolean) => {
             const invalidObject = Object.assign(
                 {}, validObject, {purposes: {invalidPurpose: randomBoolean}});
-            expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+            expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
           }));
     });
 
@@ -172,7 +173,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {purposes: invalidType});
-        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
       }));
     });
 
@@ -186,7 +187,7 @@ describe('parseJson', () => {
           (validPurposeKey: string, invalidType: any) => {
             const invalidObject = Object.assign(
                 {}, validObject, {purposes: {[validPurposeKey]: invalidType}});
-            expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+            expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
           }));
     });
 
@@ -199,7 +200,7 @@ describe('parseJson', () => {
             removeProperty(purposeKey, validObject.purposes);
         const invalidObject =
             Object.assign({}, validObject, {purposes: invalidPurposes});
-        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
       });
     });
   });
@@ -207,7 +208,7 @@ describe('parseJson', () => {
   describe('browserId key', () => {
     test('Should not acccept an empty string', () => {
       const newInvalidObject = Object.assign({}, validObject, {browserId: ''});
-      expect(parseJson(JSON.stringify(newInvalidObject))).toBeNull();
+      expect(isCmpError(parseJson(JSON.stringify(newInvalidObject)))).toBeTruthy();
     });
     test('Should accept any non-empty string', () => {
       const nonEmptyString = fc.string(1, 40).filter(s => s.trim().length > 0);
@@ -225,7 +226,7 @@ describe('parseJson', () => {
       fc.assert(fc.property(invalidType, (invalidType: any) => {
         const invalidObject =
             Object.assign({}, validObject, {browserId: invalidType});
-        expect(parseJson(JSON.stringify(invalidObject))).toBeNull();
+        expect(isCmpError(parseJson(JSON.stringify(invalidObject)))).toBeTruthy();
       }));
     });
   });
@@ -337,7 +338,7 @@ describe('isValidPurposes', () => {
 
     purposeTypes.forEach((purposeKey) => {
       const invalidPurposes = removeProperty(purposeKey, validPurposes);
-      expect(parseJson(JSON.stringify(invalidPurposes))).toBeNull();
+      expect(isCmpError(parseJson(JSON.stringify(invalidPurposes)))).toBeTruthy();
     });
   });
 });

--- a/src/model.ts
+++ b/src/model.ts
@@ -5,7 +5,7 @@ enum PurposeType {
   'essential',
   'performance',
   'functionality',
-  'presonalisedAdvertising'
+  'personalisedAdvertising'
 }
 // See:
 // https://www.typescriptlang.org/docs/handbook/enums.html#enums-at-compile-time


### PR DESCRIPTION
Refactor of the validation that enables the application to provide feedback when the submitted JSON is not valid. This means developers will be told where the error is and what the problem is with that field.

To prevent significant duplication of validation logic, the approach taken is to switch from isValid functions that return a `boolean` to validate functions that return `T|CmpError`. This means in a singe step we validate the value and return it, cleaned. If the value was not valid, the CmpError will hold information about the nature of the problem and this will be passed back to the user in the HTTP response.

In doing so, we also expand on the existing validation. Where previously we assumed many of the fields provided were of the correct type, we now explicitly validate the type of all the fields as part of the validation process.

Lots of the tests have been updated, with some missing cases now covered. The fiddly logic in the new `errors` module has its own set of detailed tests. This behaviour underpins the `T|CmpError` approach and allows us to perform multiple validations independently before bringing them together into a single result.