### PR TITLE
Further improvements

### DIFF
--- a/src/amp.ts
+++ b/src/amp.ts
@@ -1,7 +1,7 @@
 import {ConsentString} from 'consent-string';
 
 import {cmpError, CmpError, collectCmpErrors4, isCmpError} from './errors';
-import {CMPCookie} from './model';
+import {CMPRecord} from './model';
 import VENDOR_LIST from './resources/vendorlist.json';
 
 const ALL_ALLOWED_PURPOSES: number[] = [
@@ -33,8 +33,7 @@ const noConsent = (): ConsentString => {
 const consentStringFromAmpConsent = (consent: boolean): string =>
     consent ? fullConsent().getConsentString() : noConsent().getConsentString();
 
-
-const consentModelFrom = (ampUserId: string, ampConsent: boolean): CMPCookie =>
+const consentModelFrom = (ampUserId: string, ampConsent: boolean): CMPRecord =>
     ({
       iab: consentStringFromAmpConsent(ampConsent),
       source: 'amp',

--- a/src/errors.spec.ts
+++ b/src/errors.spec.ts
@@ -1,26 +1,10 @@
 /* tslint:disable:no-any */
 import fc from 'fast-check';
-import prettyFormat from 'pretty-format';
 
 import {addCmpExtensions} from './cmpErrorTestExtensions';
-import {CmpError, cmpError, collectCmpErrors, collectCmpErrors4, collectCmpErrors6, isCmpError} from './errors';
+import {CmpError, cmpError, collectCmpErrors, collectCmpErrors4, collectCmpErrors5, isCmpError} from './errors';
 
 addCmpExtensions();
-
-describe('toBeCmpError matcher', () => {
-  test('succesfully matches a cmpError', () => {
-    const value: string|CmpError = cmpError('test error');
-    expect(value).toBeCmpError();
-  });
-
-  test.skip('should fail for a non-CmpError value', () => {
-    expect('abc').toBeCmpError();
-  });
-
-  test.skip('should fail for with an empty CmpError message', () => {
-    expect(cmpError('')).toBeCmpError();
-  });
-});
 
 describe('isCmpError', () => {
   test('returns true for a value that is a cmpError', () => {
@@ -102,8 +86,7 @@ describe('collectCmpErrors6', () => {
     const c: boolean|CmpError = false;
     const d: number[]|CmpError = [1, 2, 3];
     const e: string[]|CmpError = ['foo', 'bar'];
-    const f: boolean[]|CmpError = [true, false];
-    expect(collectCmpErrors6(a, b, c, d, e, f)).toEqual([a, b, c, d, e, f]);
+    expect(collectCmpErrors5(a, b, c, d, e)).toEqual([a, b, c, d, e]);
   });
 
   test('retuns a CmpError if the first item is a failure', () => {
@@ -112,8 +95,7 @@ describe('collectCmpErrors6', () => {
     const c: boolean|CmpError = false;
     const d: number[]|CmpError = [1, 2, 3];
     const e: string[]|CmpError = ['foo', 'bar'];
-    const f: boolean[]|CmpError = [true, false];
-    expect(collectCmpErrors6(a, b, c, d, e, f)).toBeCmpError();
+    expect(collectCmpErrors5(a, b, c, d, e)).toBeCmpError();
   });
 
   test('retuns a CmpError if the second item is a failure', () => {
@@ -122,8 +104,7 @@ describe('collectCmpErrors6', () => {
     const c: boolean|CmpError = false;
     const d: number[]|CmpError = [1, 2, 3];
     const e: string[]|CmpError = ['foo', 'bar'];
-    const f: boolean[]|CmpError = [true, false];
-    expect(collectCmpErrors6(a, b, c, d, e, f)).toBeCmpError();
+    expect(collectCmpErrors5(a, b, c, d, e)).toBeCmpError();
   });
 
   test('retuns a CmpError if the third item is a failure', () => {
@@ -132,8 +113,7 @@ describe('collectCmpErrors6', () => {
     const c: boolean|CmpError = cmpError('third item failure');
     const d: number[]|CmpError = [1, 2, 3];
     const e: string[]|CmpError = ['foo', 'bar'];
-    const f: boolean[]|CmpError = [true, false];
-    expect(collectCmpErrors6(a, b, c, d, e, f)).toBeCmpError();
+    expect(collectCmpErrors5(a, b, c, d, e)).toBeCmpError();
   });
 
   test('retuns a CmpError if the fourth item is a failure', () => {
@@ -142,8 +122,7 @@ describe('collectCmpErrors6', () => {
     const c: boolean|CmpError = false;
     const d: number[]|CmpError = cmpError('fourth item failure');
     const e: string[]|CmpError = ['foo', 'bar'];
-    const f: boolean[]|CmpError = [true, false];
-    expect(collectCmpErrors6(a, b, c, d, e, f)).toBeCmpError();
+    expect(collectCmpErrors5(a, b, c, d, e)).toBeCmpError();
   });
 
   test('retuns a CmpError if the fifth item is a failure', () => {
@@ -152,19 +131,9 @@ describe('collectCmpErrors6', () => {
     const c: boolean|CmpError = false;
     const d: number[]|CmpError = [1, 2, 3];
     const e: string[]|CmpError = cmpError('fifth item failure');
-    const f: boolean[]|CmpError = [true, false];
-    expect(collectCmpErrors6(a, b, c, d, e, f)).toBeCmpError();
+    expect(collectCmpErrors5(a, b, c, d, e)).toBeCmpError();
   });
 
-  test('retuns a CmpError if the sixth item is a failure', () => {
-    const a: string|CmpError = 'string';
-    const b: number|CmpError = 1;
-    const c: boolean|CmpError = false;
-    const d: number[]|CmpError = [1, 2, 3];
-    const e: string[]|CmpError = ['foo', 'bar'];
-    const f: boolean[]|CmpError = cmpError('sixth item failure');
-    expect(collectCmpErrors6(a, b, c, d, e, f)).toBeCmpError();
-  });
 
   test('returns the provided error message for a single failure', () => {
     const a: string|CmpError = cmpError('test error message');
@@ -172,8 +141,7 @@ describe('collectCmpErrors6', () => {
     const c: boolean|CmpError = false;
     const d: number[]|CmpError = [1, 2, 3];
     const e: string[]|CmpError = ['foo', 'bar'];
-    const f: boolean[]|CmpError = [true, false];
-    const result = collectCmpErrors6(a, b, c, d, e, f);
+    const result = collectCmpErrors5(a, b, c, d, e);
     expect(result).toBeCmpErrorWithMessage('test error message');
   });
 
@@ -183,8 +151,7 @@ describe('collectCmpErrors6', () => {
     const c: boolean|CmpError = false;
     const d: number[]|CmpError = [1, 2, 3];
     const e: string[]|CmpError = ['foo', 'bar'];
-    const f: boolean[]|CmpError = [true, false];
-    const result = collectCmpErrors6(a, b, c, d, e, f);
+    const result = collectCmpErrors5(a, b, c, d, e);
     expect(result).toBeCmpErrorWithMessage(
         'test error message, another error message');
   });
@@ -218,5 +185,41 @@ describe('collectCmpErrors', () => {
         [cmpError('test error message'), cmpError('another error message'), 1]);
     expect(result).toBeCmpErrorWithMessage(
         'test error message, another error message');
+  });
+});
+
+describe('toBeCmpError matcher', () => {
+  test('succesfully matches a cmpError', () => {
+    const value: string|CmpError = cmpError('test error');
+    expect(value).toBeCmpError();
+  });
+
+  // unskip these to make sure they cause failed tests
+
+  test.skip('should fail for a non-CmpError value', () => {
+    expect('abc').toBeCmpError();
+  });
+
+  test.skip('should fail for a CmpError, even if the message is empty', () => {
+    expect(cmpError('')).toBeCmpError();
+  });
+});
+
+describe('toBeCmpErrorWithMessage', () => {
+  test('successfully matches a cmpError with expected message', () => {
+    fc.assert(fc.property(fc.string(), (message) => {
+      expect(cmpError(message)).toBeCmpErrorWithMessage(message);
+    }));
+  });
+
+  // unskip these to make sure they cause failed tests
+
+  test.skip(
+      'should fail if the CmpError does not have the correct message', () => {
+        expect(cmpError('wrong message')).toBeCmpErrorWithMessage('message');
+      });
+
+  test.skip('should fail if the result is not a CmpError', () => {
+    expect(1).toBeCmpErrorWithMessage('message');
   });
 });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -13,29 +13,25 @@ function isCmpError<T>(value: CmpError|T): value is CmpError {
 function collectCmpErrors4<A, B, C, D>(
     a: CmpError|A, b: CmpError|B, c: CmpError|C,
     d: CmpError|D): CmpError|[A, B, C, D] {
-  if (isCmpError(a) || isCmpError(b) || isCmpError(c) || isCmpError(d)) {
+  if (!isCmpError(a) && !isCmpError(b) && !isCmpError(c) && !isCmpError(d)) {
+    return [a, b, c, d];
+  } else {
     const combinedError =
         [a, b, c, d].filter(isCmpError).map((err) => err.message).join(', ');
     return cmpError(combinedError);
-  } else {
-    // no errors exist so we know that this is `[A, B, C, D]`
-    return [a as A, b as B, c as C, d as D];
   }
 }
 
-function collectCmpErrors6<A, B, C, D, E, F>(
-    a: CmpError|A, b: CmpError|B, c: CmpError|C, d: CmpError|D, e: CmpError|E,
-    f: CmpError|F): CmpError|[A, B, C, D, E, F] {
-  if (isCmpError(a) || isCmpError(b) || isCmpError(c) || isCmpError(d) ||
-      isCmpError(e) || isCmpError(f)) {
-    const combinedError = [a, b, c, d, e, f]
-                              .filter(isCmpError)
-                              .map((err) => err.message)
-                              .join(', ');
-    return cmpError(combinedError);
+function collectCmpErrors5<A, B, C, D, E>(
+    a: CmpError|A, b: CmpError|B, c: CmpError|C, d: CmpError|D,
+    e: CmpError|E): CmpError|[A, B, C, D, E] {
+  if (!isCmpError(a) && !isCmpError(b) && !isCmpError(c) && !isCmpError(d) &&
+      !isCmpError(e)) {
+    return [a, b, c, d, e];
   } else {
-    // no errors exist so we know that this is `[A, B, C, D]`
-    return [a as A, b as B, c as C, d as D, e as E, f as F];
+    const combinedError =
+        [a, b, c, d, e].filter(isCmpError).map((err) => err.message).join(', ');
+    return cmpError(combinedError);
   }
 }
 
@@ -56,5 +52,5 @@ export {
   isCmpError,
   collectCmpErrors,
   collectCmpErrors4,
-  collectCmpErrors6
+  collectCmpErrors5
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import {provider} from 'aws-sdk/lib/credentials/credential_provider_chain';
 
 import {AmpConsentBody, consentModelFrom, getAmpConsentBody} from './amp';
 import {CmpError, isCmpError} from './errors';
-import {CMPCookie, parseJson} from './model';
+import {CMPRecord, parseJson} from './model';
 
 const STREAM_NAME: string|undefined = process.env.STREAM_NAME;
 
@@ -60,7 +60,7 @@ function serviceUnavailable(
 }
 
 const putConsentToFirehose =
-    (cmpCookie: CMPCookie, callback: APIGatewayProxyCallback,
+    (cmpCookie: CMPRecord, callback: APIGatewayProxyCallback,
      streamName: string) => {
       fh.putRecord(
           {
@@ -90,7 +90,7 @@ const handleAmp =
               event.body}`);
           bad('Body for AMP consent request seems to be invalid', callback);
         } else {
-          const cmpCookie: CMPCookie = consentModelFrom(
+          const cmpCookie: CMPRecord = consentModelFrom(
               ampConsentBody.ampUserId, ampConsentBody.consentState);
           try {
             putConsentToFirehose(cmpCookie, callback, streamName);

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,5 +1,5 @@
 import {ConsentString} from 'consent-string';
-import {CmpError, cmpError, collectCmpErrors, collectCmpErrors6, isCmpError} from './errors';
+import {CmpError, cmpError, collectCmpErrors, collectCmpErrors5, isCmpError} from './errors';
 
 enum PurposeType {
   'essential',
@@ -159,21 +159,21 @@ const validateTime = (time: any): number|CmpError => {
 const validateObject =
     /* tslint:disable-next-line:no-any */
     (jsonObject: {[key: string]: any}): CmpError|CMPCookie => {
-      const result = collectCmpErrors6(
+      const result = collectCmpErrors5(
           validateConsentString(jsonObject.iab),
-          validateVersion(jsonObject.version), validateTime(jsonObject.time),
+          validateVersion(jsonObject.version),
           validateSourceType(jsonObject.source),
           validatePurposes(jsonObject.purposes),
           validateBrowserId(jsonObject.browserId));
       if (isCmpError(result)) {
         return result;
       } else {
-        const [consentString, version, time, sourceType, purposes, browserId] =
+        const [consentString, version, sourceType, purposes, browserId] =
             result;
         return {
           iab: consentString,
           version,
-          time,
+          time: Date.now(),
           source: sourceType,
           purposes,
           browserId
@@ -199,6 +199,7 @@ export let _ = {
   validateConsentString,
   validatePurposes,
   validateBrowserId,
+  validateObject,
   sourceTypes,
   purposeTypes,
   isNonEmpty,

--- a/src/model.ts
+++ b/src/model.ts
@@ -24,7 +24,7 @@ type PurposeList = {
   [key in PurposeString]: boolean
 };
 
-type CMPCookie = {
+type CMPRecord = {
   iab: string,
   version: string,
   time: number,
@@ -49,7 +49,10 @@ const validateSourceType = (sourceType: any): SourceString|CmpError => {
   if (typeof sourceType === 'string') {
     const valid = sourceTypes.includes(sourceType);
     // cast is safe because we've checked this is a sourceType
-    return valid ? sourceType as SourceString : cmpError('invalid sourceType');
+    return valid ?
+        sourceType as SourceString :
+        cmpError(
+            `invalid sourceType, expected one of ${sourceTypes.join(', ')}`);
   } else {
     return cmpError('expected string for sourceType');
   }
@@ -158,7 +161,7 @@ const validateTime = (time: any): number|CmpError => {
 
 const validateObject =
     /* tslint:disable-next-line:no-any */
-    (jsonObject: {[key: string]: any}): CmpError|CMPCookie => {
+    (jsonObject: {[key: string]: any}): CmpError|CMPRecord => {
       const result = collectCmpErrors5(
           validateConsentString(jsonObject.iab),
           validateVersion(jsonObject.version),
@@ -181,7 +184,7 @@ const validateObject =
       }
     };
 
-const parseJson = (json: string): CmpError|CMPCookie => {
+const parseJson = (json: string): CmpError|CMPRecord => {
   try {
     const parsedJson: object = JSON.parse(json);
     return validateObject(parsedJson);
@@ -190,7 +193,7 @@ const parseJson = (json: string): CmpError|CMPCookie => {
   }
 };
 
-export {parseJson, CMPCookie};
+export {parseJson, CMPRecord};
 
 export let _ = {
   isNumber,


### PR DESCRIPTION
The main change is the removal of the time field from submissions. This meant trusting the time given by the client, which we don't want to do in this case. The time is now added by the server as part of processing the submission record.

This also further tidies the codebase, renaming the `CmpCookie` type to `CmpRecord` to better reflect its purpose, and fixing some unimplemented tests.
