### PR TITLE
Append newline at the end of a JSON record

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ const putConsentToFirehose =
       fh.putRecord(
           {
             DeliveryStreamName: streamName,
-            Record: {Data: new Buffer(JSON.stringify(cmpCookie))}
+            Record: {Data: new Buffer(`${JSON.stringify(cmpCookie)}\n`)}
           },
           (err, data) => {
             if (err) {


### PR DESCRIPTION
We need to append a new line at the end of the record as otherwise firehose will smack them in together which in turn makes spark read in only one JSON record.