### PR TITLE
Include variant in cmp record

### DIFF
--- a/src/errors.spec.ts
+++ b/src/errors.spec.ts
@@ -16,6 +16,10 @@ describe('isCmpError', () => {
     const value: string|CmpError = 'not an error';
     expect(isCmpError(value)).toBe(false);
   });
+
+  test('returns false for an undefined value', () => {
+    expect(isCmpError(undefined)).toBe(false);
+  });
 });
 
 describe('collectCmpErrors4', () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -7,7 +7,11 @@ const cmpError = (message: string): CmpError => {
 };
 
 function isCmpError<T>(value: CmpError|T): value is CmpError {
-  return (value as CmpError).message !== undefined;
+  if (typeof value === 'undefined') {
+    return false;
+  } else {
+    return (value as CmpError).message !== undefined;
+  }
 }
 
 function collectCmpErrors4<A, B, C, D>(

--- a/src/model.ts
+++ b/src/model.ts
@@ -37,7 +37,8 @@ export type CmpRecordV1 = {
   time: number,
   source: Source,
   purposes: V1PurposeObj,
-  browserId: string
+  browserId: string,
+  variant?: string
 };
 // CMP that includes PECR purposes
 export type CmpRecordV2 = {
@@ -46,6 +47,7 @@ export type CmpRecordV2 = {
   time: number,
   source: Source,
   purposes: V2PurposeObj,
-  browserId: string
+  browserId: string,
+  variant?: string
 };
 export type CmpRecord = CmpRecordV1|CmpRecordV2;

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,6 +1,6 @@
 import {ConsentString} from 'consent-string';
 
-import {CmpError, cmpError, collectCmpErrors, collectCmpErrors4, isCmpError} from './errors';
+import {CmpError, cmpError, collectCmpErrors, collectCmpErrors5, isCmpError} from './errors';
 import {CmpRecordV1, CmpRecordV2, Source, sources, V1PurposeObj, v1Purposes, V2PurposeObj, v2Purposes, Version, versions} from './model';
 import {assertUnreachable} from './utilities';
 
@@ -13,6 +13,23 @@ const validateBoolean = (value: any, label: string): boolean|CmpError => {
     return cmpError(`expected boolean for ${label}, got ${value}`);
   }
 };
+
+const validateOptionalString =
+    /* tslint:disable-next-line:no-any */
+    (value: any, label: string): string|undefined|CmpError => {
+      if (typeof value === 'string') {
+        if (value.length > 0) {
+          return value;
+        } else {
+          return cmpError(`empty string is not allowed for ${label}`);
+        }
+      } else if (typeof value === 'undefined') {
+        return undefined;
+      } else {
+        return cmpError(
+            `${label} is optional, but must be a string if present`);
+      }
+    };
 
 const validateStringKey =
     /* tslint:disable-next-line:no-any */
@@ -171,22 +188,25 @@ const validateObject =
 const validateV1Object =
     /* tslint:disable-next-line:no-any */
     (jsonObject: {[key: string]: any}): CmpError|CmpRecordV1 => {
-      const result = collectCmpErrors4(
+      const result = collectCmpErrors5(
           validateIabConsentString(jsonObject.iab),
           validateSourceType(jsonObject.source),
           validateV1Purposes(jsonObject.purposes),
-          validateBrowserId(jsonObject.browserId));
+          validateBrowserId(jsonObject.browserId),
+          validateOptionalString(jsonObject.variant, 'variant'));
       if (isCmpError(result)) {
         return result;
       } else {
-        const [consentString, sourceType, purposes, browserId] = result;
+        const [consentString, sourceType, purposes, browserId, variant] =
+            result;
         return {
           iab: consentString,
           version: '1',
           time: Date.now(),
           source: sourceType,
           purposes,
-          browserId
+          browserId,
+          variant
         };
       }
     };
@@ -194,22 +214,25 @@ const validateV1Object =
 const validateV2Object =
     /* tslint:disable-next-line:no-any */
     (jsonObject: {[key: string]: any}): CmpError|CmpRecordV2 => {
-      const result = collectCmpErrors4(
+      const result = collectCmpErrors5(
           validateIabConsentString(jsonObject.iab),
           validateSourceType(jsonObject.source),
           validateV2Purposes(jsonObject.purposes),
-          validateBrowserId(jsonObject.browserId));
+          validateBrowserId(jsonObject.browserId),
+          validateOptionalString(jsonObject.variant, 'variant'));
       if (isCmpError(result)) {
         return result;
       } else {
-        const [consentString, sourceType, purposes, browserId] = result;
+        const [consentString, sourceType, purposes, browserId, variant] =
+            result;
         return {
           iab: consentString,
           version: '2',
           time: Date.now(),
           source: sourceType,
           purposes,
-          browserId
+          browserId,
+          variant
         };
       }
     };
@@ -233,6 +256,7 @@ export let _ = {
   validateBrowserId,
   validateVersion,
   validateObject,
+  validateOptionalString,
   validateStringKey,
   validateBoolean,
   isNonEmpty,


### PR DESCRIPTION
Test variants may include text changes and we need to be able to evidence exactly what the user was shown. Accordingly, there is now an optional variant in the CmpRecord types so that clients can store the variant a user was shown alongside the corresponding consent record.

This change uncovered a bug in `isCmpError` when given undefined values, which is now addressed.
