### PR TITLE
Cors support

### DIFF
--- a/cfn.template.yaml
+++ b/cfn.template.yaml
@@ -1,5 +1,27 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Consent logs stack with Lambda-> Kinesis Firehose-> S3
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: Config
+      Parameters:
+      - Stage
+      - DistBucket
+      - CorsWhitelist
+    - Label:
+        default: Networking
+      Parameters:
+      - FrontendVpcId
+      - FrontendSubnets
+    - Label:
+        default: DNS
+      Parameters:
+      - DomainName
+      - HostedZoneId
+      - CertificateArn
+
 Parameters:
   Stage:
     Description: Stage name
@@ -12,18 +34,21 @@ Parameters:
     Description: S3 bucket holding the lambda code
     Type: String
     Default: aws-frontend-artifacts
+  CorsWhitelist:
+    Description: Whitelisted domains for CORS access, comma-separated with preceeding . to allow all subdomains
+    Type: String
   FrontendVpcId:
     Description: Frontend VPC ID
     Type: AWS::EC2::VPC::Id
   FrontendSubnets:
     Description: Frontend Subnets to launch ALB into
     Type: List<AWS::EC2::Subnet::Id>
-  HostedZoneId:
-    Description: The HostedZone where the CNAME RecordSet will live in
-    Type: AWS::Route53::HostedZone::Id
   DomainName:
     Description: The fully qualified domain name within the hosted zone (has to match Hosted Zone domain AND certificate domain)
     Type: String
+  HostedZoneId:
+    Description: The HostedZone where the CNAME RecordSet will live in
+    Type: AWS::Route53::HostedZone::Id
   CertificateArn:
     Description: The ARN of the certificate that the ALB will use to serve requests (Domain on certificate has to match DomainName)
     Type: String
@@ -106,6 +131,7 @@ Resources:
       Environment:
         Variables:
           STREAM_NAME: !Ref KinesisFirehoseDeliveryStream
+          CORS_WHITELIST: !Ref CorsWhitelist
       Tags:
         - { Key: Stack, Value: !FindInMap [Constants, Stack, Value] }
         - { Key: App, Value: !FindInMap [Constants, App, Value] }

--- a/src/cors.spec.ts
+++ b/src/cors.spec.ts
@@ -1,0 +1,182 @@
+import {URL} from 'url';
+
+import {_, corsCheck, parseCorsWhitelist} from './cors';
+
+const {getHostname, hostnameMatches} = _;
+
+describe('corsCheck', () => {
+  const whitelist = ['.example.com', 'localhost'];
+
+  test('echoes the url for a valid subdomain match', () => {
+    const url = 'https://test.example.com/abc';
+    const result = corsCheck(url, whitelist);
+    if (result) {
+      expect(result.origin).toEqual(url);
+    } else {
+      fail('expected CORS headers object from whitelisted URL');
+    }
+  });
+
+  test('echoes the url for a valid exact match', () => {
+    const url = 'http://localhost/abc';
+    const result = corsCheck(url, whitelist);
+    if (result) {
+      expect(result.origin).toEqual(url);
+    } else {
+      fail('expected CORS headers object from whitelisted URL');
+    }
+  });
+
+  test('returns undefined for a non-whitelisted url', () => {
+    const result = corsCheck('http://foo.com/abc', whitelist);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('getHostname', () => {
+  test('extracts the hostname from a URL', () => {
+    expect(getHostname('https://example.com')).toEqual('example.com');
+  });
+
+  test('extracts the hostname from a locahost URL', () => {
+    expect(getHostname('http://localhost')).toEqual('localhost');
+  });
+
+  test('extracts the hostname from a locahost URL with port', () => {
+    expect(getHostname('http://localhost:8000')).toEqual('localhost');
+  });
+
+  test('extracts the hostname from a locahost URL with port, path etc', () => {
+    expect(getHostname('http://localhost:8000/test?abc#123'))
+        .toEqual('localhost');
+  });
+
+  test('extracts the hostname from a raw IP address URL', () => {
+    expect(getHostname('http://10.0.0.1:8000/test?abc#123'))
+        .toEqual('10.0.0.1');
+  });
+});
+
+describe('hostnameMatches', () => {
+  describe('for literal host whitelist', () => {
+    test('matches localhost', () => {
+      expect(hostnameMatches('localhost', 'localhost')).toBeTruthy();
+    });
+
+    test('matches proper domain', () => {
+      expect(hostnameMatches('test.example.com', 'test.example.com'))
+          .toBeTruthy();
+    });
+
+    test('does not match subdomain of literal whitelist entry', () => {
+      expect(hostnameMatches('test.example.com', 'example.com')).toBeFalsy();
+    });
+
+    test('does not match apex of literal subdomain whitelist entry', () => {
+      expect(hostnameMatches('example.com', 'test.example.com')).toBeFalsy();
+    });
+
+    test('does not match different domain', () => {
+      expect(hostnameMatches('foo.com', 'example.com')).toBeFalsy();
+    });
+
+    test('does not match similar domain', () => {
+      expect(hostnameMatches('foo-example.com', 'example.com')).toBeFalsy();
+    });
+
+    test('matches literal IP', () => {
+      expect(hostnameMatches('192.168.0.1', '192.168.0.1')).toBeTruthy();
+    });
+
+    test('does not matche different IP', () => {
+      expect(hostnameMatches('192.168.0.10', '192.168.0.1')).toBeFalsy();
+    });
+  });
+
+  describe('for .-prefixed wildcard whitelist entry', () => {
+    describe('apex matching', () => {
+      test('matches apex of wild localhost', () => {
+        expect(hostnameMatches('localhost', '.localhost')).toBeTruthy();
+      });
+
+      test('matches apex of wild proper domain', () => {
+        expect(hostnameMatches('example.com', '.example.com')).toBeTruthy();
+      });
+
+      test('matches apex of wild proper subdomain', () => {
+        expect(hostnameMatches('test.example.com', '.test.example.com'))
+            .toBeTruthy();
+      });
+    });
+
+    describe('subdomain matching', () => {
+      test('matches subdomain of wild localhost', () => {
+        expect(hostnameMatches('sub.localhost', '.localhost')).toBeTruthy();
+      });
+
+      test('matches subdomain of wild proper domain', () => {
+        expect(hostnameMatches('sub.example.com', '.example.com')).toBeTruthy();
+      });
+
+      test('matches subdomain of wild proper subdomain', () => {
+        expect(hostnameMatches('sub.test.example.com', '.test.example.com'))
+            .toBeTruthy();
+      });
+
+      test('matches nested subdomains of wild whitelist entry', () => {
+        expect(hostnameMatches('sub.test.example.com', '.example.com'))
+            .toBeTruthy();
+      });
+    });
+
+    describe('superdomain matching', () => {
+      test('fails to match superdomain of wild proper domain', () => {
+        expect(hostnameMatches('localhost', '.example.localhost')).toBeFalsy();
+      });
+
+      test('fails to match superdomain of wild subdomain entry', () => {
+        expect(hostnameMatches('example.com', '.test.example.com')).toBeFalsy();
+      });
+    });
+
+    describe('mismatched hosts', () => {
+      test('does not match different domain', () => {
+        expect(hostnameMatches('foo.com', '.example.com')).toBeFalsy();
+      });
+
+      test('does not match different subdomain on a different domain', () => {
+        expect(hostnameMatches('test.foo.com', '.example.com')).toBeFalsy();
+      });
+
+      test('does not match similar domain that shares a prefix', () => {
+        expect(hostnameMatches('example.com.au', '.example.com')).toBeFalsy();
+      });
+
+      test('does not match similar (sub)domain that shares a prefix', () => {
+        expect(hostnameMatches('foo.example.com.au', '.example.com'))
+            .toBeFalsy();
+      });
+
+      test('does not match different domain that shares a suffix', () => {
+        expect(hostnameMatches('foo-example.com', '.example.com')).toBeFalsy();
+      });
+    });
+  });
+});
+
+describe('parseCorsWhitelist', () => {
+  test('parses the example CORS whitelist', () => {
+    const result = parseCorsWhitelist('localhost,.example.com');
+    expect(result).toEqual(['localhost', '.example.com']);
+  });
+
+  test('parses a single entry CORS whitelist', () => {
+    const result = parseCorsWhitelist('localhost');
+    expect(result).toEqual(['localhost']);
+  });
+
+  test('strips empty records', () => {
+    const result = parseCorsWhitelist('localhost,.example.com,');
+    expect(result).toEqual(['localhost', '.example.com']);
+  });
+});

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,0 +1,56 @@
+import {URL} from 'url';
+
+
+const getHostname = (url: string): string => {
+  const parsedUrl = new URL(url);
+  return parsedUrl.hostname;
+};
+
+const hostnameMatches = (hostname: string, whitelistEntry: string): boolean => {
+  if (whitelistEntry.length <= 0) {
+    throw new Error('Empty entry in CORS domain whitelist is not allowed');
+  } else if (whitelistEntry.charAt(0) === '.') {
+    // wildcard matching
+    return hostname.endsWith(whitelistEntry) ||
+        hostname === whitelistEntry.substr(1);
+  } else {
+    // literal matching
+    return hostname === whitelistEntry;
+  }
+};
+
+// check this url's hostname against all whitelisted domains
+const checkHostname = (url: string, whitelist: string[]): boolean => {
+  const hostname = getHostname(url);
+  return whitelist.some(
+      whitelistEntry => hostnameMatches(hostname, whitelistEntry));
+};
+
+export const parseCorsWhitelist = (whitelistStr: string): string[] => {
+  return whitelistStr.split(',').filter(entry => entry.length > 0);
+};
+
+export const corsCheck =
+    (url: string, whitelist: string[]): CorsHeaders|undefined => {
+      if (checkHostname(url, whitelist)) {
+        return {
+          origin: url,
+          methods: 'POST, GET, OPTIONS',
+          headers: 'Content-Type, Origin, Accept',
+        };
+      } else {
+        return undefined;
+      }
+    };
+
+export interface CorsHeaders {
+  origin: string;
+  headers: string;
+  methods: string;
+}
+
+export let _ = {
+  getHostname,
+  hostnameMatches,
+  checkHostname
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,8 @@ const fh = new AWS.Firehose({
 });
 
 function respond(
-    statusCode: number, callback: APIGatewayProxyCallback, bodyData?: {},
-    cors?: CorsHeaders): void {
+    statusCode: number, callback: APIGatewayProxyCallback, cors?: CorsHeaders,
+    bodyData?: {}): void {
   const body = bodyData ? JSON.stringify(bodyData) : '';
   if (cors) {
     return callback(null, {
@@ -64,7 +64,7 @@ function respond(
 function ok(
     message: string, callback: APIGatewayProxyCallback,
     cors: CorsHeaders): void {
-  respond(200, callback, {response: message}, cors);
+  respond(200, callback, cors, {response: message});
 }
 
 function okNoContent(
@@ -75,25 +75,25 @@ function okNoContent(
 function bad(
     message: string, callback: APIGatewayProxyCallback,
     cors: CorsHeaders): void {
-  respond(400, callback, {response: message}, cors);
+  respond(400, callback, cors, {response: message});
 }
 
 function notFound(
     message: string, callback: APIGatewayProxyCallback,
     cors: CorsHeaders): void {
-  respond(404, callback, {response: message}, cors);
+  respond(404, callback, cors, {response: message});
 }
 
 function serviceUnavailable(
     message: string, callback: APIGatewayProxyCallback,
     cors?: CorsHeaders): void {
-  respond(503, callback, {response: message}, cors);
+  respond(503, callback, cors, {response: message});
 }
 
 function forbidden(
     message: string, callback: APIGatewayProxyCallback,
     cors?: CorsHeaders): void {
-  respond(403, callback, {response: message}, cors);
+  respond(403, callback, cors, {response: message});
 }
 
 const putConsentToFirehose =

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,13 @@ import AWS from 'aws-sdk';
 import {provider} from 'aws-sdk/lib/credentials/credential_provider_chain';
 
 import {AmpConsentBody, consentModelFrom, getAmpConsentBody} from './amp';
+import {corsCheck, CorsHeaders, parseCorsWhitelist} from './cors';
 import {CmpError, isCmpError} from './errors';
 import {CmpRecord} from './model';
 import {parseJson} from './validation';
 
 const STREAM_NAME: string|undefined = process.env.STREAM_NAME;
+const CORS_WHITELIST: string|undefined = process.env.CORS_WHITELIST;
 
 function getCredentialProviderChain(): AWS.CredentialProviderChain {
   // Initiate provider chain like this,
@@ -32,37 +34,71 @@ const fh = new AWS.Firehose({
 });
 
 function respond(
-    statusCode: number, body: {}, callback: APIGatewayProxyCallback): void {
-  callback(null, {
-    statusCode,
-    headers: {
-      'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*'
-    },
-    body: JSON.stringify(body)
-  });
+    statusCode: number, callback: APIGatewayProxyCallback, bodyData?: {},
+    cors?: CorsHeaders): void {
+  const body = bodyData ? JSON.stringify(bodyData) : '';
+  if (cors) {
+    return callback(null, {
+      statusCode,
+      headers: {
+        'Content-Type': 'application/json',
+        'Vary': 'Accept-Encoding, Origin',
+        'Access-Control-Allow-Origin': cors.origin,
+        'Access-Control-Allow-Methods': cors.methods,
+        'Access-Control-Allow-Headers': cors.headers,
+      },
+      body
+    });
+  } else {
+    return callback(null, {
+      statusCode,
+      headers: {
+        'Content-Type': 'application/json',
+        'Vary': 'Accept-Encoding, Origin',
+      },
+      body
+    });
+  }
 }
 
-function ok(message: string, callback: APIGatewayProxyCallback): void {
-  respond(200, {response: message}, callback);
+function ok(
+    message: string, callback: APIGatewayProxyCallback,
+    cors: CorsHeaders): void {
+  respond(200, callback, {response: message}, cors);
 }
 
-function bad(message: string, callback: APIGatewayProxyCallback): void {
-  respond(400, {response: message}, callback);
+function okNoContent(
+    callback: APIGatewayProxyCallback, cors: CorsHeaders): void {
+  respond(204, callback, cors);
 }
 
-function notFound(message: string, callback: APIGatewayProxyCallback): void {
-  respond(404, {response: message}, callback);
+function bad(
+    message: string, callback: APIGatewayProxyCallback,
+    cors: CorsHeaders): void {
+  respond(400, callback, {response: message}, cors);
+}
+
+function notFound(
+    message: string, callback: APIGatewayProxyCallback,
+    cors: CorsHeaders): void {
+  respond(404, callback, {response: message}, cors);
 }
 
 function serviceUnavailable(
-    message: string, callback: APIGatewayProxyCallback): void {
-  respond(503, {response: message}, callback);
+    message: string, callback: APIGatewayProxyCallback,
+    cors?: CorsHeaders): void {
+  respond(503, callback, {response: message}, cors);
+}
+
+function forbidden(
+    message: string, callback: APIGatewayProxyCallback,
+    cors?: CorsHeaders): void {
+  respond(403, callback, {response: message}, cors);
 }
 
 const putConsentToFirehose =
     (cmpRecord: CmpRecord, callback: APIGatewayProxyCallback,
-     streamName: string) => {
+     streamName: string, cors: CorsHeaders) => {
       fh.putRecord(
           {
             DeliveryStreamName: streamName,
@@ -71,82 +107,110 @@ const putConsentToFirehose =
           (err, data) => {
             if (err) {
               console.log('Error writing to kinesis stream', err, err.stack);
-              serviceUnavailable('Could not save consent record', callback);
+              serviceUnavailable(
+                  'Could not save consent record', callback, cors);
             } else {
               console.log(
                   'successfully added record to Kinesis stream', data.RecordId);
-              ok('ok', callback);
+              ok('ok', callback, cors);
             }
           });
     };
 
 const handleAmp =
     (event: APIGatewayProxyEvent, context: Context,
-     callback: APIGatewayProxyCallback, streamName: string) => {
+     callback: APIGatewayProxyCallback, streamName: string,
+     cors: CorsHeaders) => {
       if (event.body) {
         const ampConsentBody: CmpError|AmpConsentBody =
             getAmpConsentBody(event.body);
         if (isCmpError(ampConsentBody)) {
           console.log(`Error '${ampConsentBody.message}' validating AMP body ${
               event.body}`);
-          bad('Body for AMP consent request seems to be invalid', callback);
+          bad('Body for AMP consent request seems to be invalid', callback,
+              cors);
         } else {
           const cmpCookie: CmpRecord = consentModelFrom(
               ampConsentBody.ampUserId, ampConsentBody.consentState);
           try {
-            putConsentToFirehose(cmpCookie, callback, streamName);
+            putConsentToFirehose(cmpCookie, callback, streamName, cors);
           } catch (exception) {
             console.error(
                 'Error while writing AMP submission to Kinesis stream',
                 exception);
-            bad('Unable to write consent record', callback);
+            bad('Unable to write consent record', callback, cors);
           }
         }
       } else {
         console.log('No request body');
-        bad('No request body', callback);
+        bad('No request body', callback, cors);
       }
     };
 
 const handler: APIGatewayProxyHandler =
     (event: APIGatewayProxyEvent, context: Context,
      callback: APIGatewayProxyCallback) => {
-      if (STREAM_NAME) {
-        if (event.path === '/report/amp') {
-          return handleAmp(event, context, callback, STREAM_NAME);
-        } else if (event.path === '/report') {
-          // make consent record
-          if (event.body != null) {
-            const consentResult = parseJson(event.body);
-            if (isCmpError(consentResult)) {
-              console.log(
-                  `Error '${consentResult.message}' validating request body ${
-                      event.body}`);
-              bad(`Body for consent request seems to be invalid: ${
-                      consentResult.message}`,
-                  callback);
-            } else {
-              try {
-                putConsentToFirehose(consentResult, callback, STREAM_NAME);
-              } catch (exception) {
-                console.error(
-                    'Error while writing consent to Kinesis stream', exception);
-                bad('Unable to write consent record', callback);
-              }
-            }
+      const requestOrigin = (event.headers && event.headers.origin) || '';
+      if (CORS_WHITELIST) {
+        const corsWhitelist = parseCorsWhitelist(CORS_WHITELIST);
+        const corsHeaders = corsCheck(requestOrigin, corsWhitelist);
+        if (corsHeaders) {
+          if (event.httpMethod === 'OPTIONS') {
+            // just CORS preflight request
+            okNoContent(callback, corsHeaders);
           } else {
-            console.log('No body provided');
-            bad('No body provided', callback);
+            if (STREAM_NAME) {
+              if (event.path === '/report/amp') {
+                return handleAmp(
+                    event, context, callback, STREAM_NAME, corsHeaders);
+              } else if (event.path === '/report') {
+                // make consent record
+                if (event.body != null) {
+                  const consentResult = parseJson(event.body);
+                  if (isCmpError(consentResult)) {
+                    console.log(`Error '${
+                        consentResult.message}' validating request body ${
+                        event.body}`);
+                    bad(`Body for consent request seems to be invalid: ${
+                            consentResult.message}`,
+                        callback, corsHeaders);
+                  } else {
+                    try {
+                      putConsentToFirehose(
+                          consentResult, callback, STREAM_NAME, corsHeaders);
+                    } catch (exception) {
+                      console.error(
+                          'Error while writing consent to Kinesis stream',
+                          exception);
+                      bad('Unable to write consent record', callback,
+                          corsHeaders);
+                    }
+                  }
+                } else {
+                  console.log('No body provided');
+                  bad('No body provided', callback, corsHeaders);
+                }
+              } else {
+                console.log('Not found');
+                notFound('Not found', callback, corsHeaders);
+              }
+            } else {
+              console.error('Missing STREAM_NAME from the environment');
+              serviceUnavailable(
+                  `Missing STREAM_NAME from the environment: STREAM_NAME: ${
+                      STREAM_NAME}`,
+                  callback);
+            }
           }
         } else {
-          console.log('Not found');
-          notFound('Not found', callback);
+          console.error(`Cors check failed for origin ${requestOrigin}`);
+          forbidden('Invalid Origin', callback);
         }
       } else {
-        console.error('Missing STREAM_NAME from the environment');
+        console.error('Missing CORS_WHITELIST from the environment');
         serviceUnavailable(
-            `Missing STREAM_NAME from the environment: STREAM_NAME: ${
-                STREAM_NAME}`,
+            `Missing CORS_WHITELIST from the environment: CORS_WHITELIST: ${
+                CORS_WHITELIST}`,
             callback);
       }
     };


### PR DESCRIPTION
## Proper CORS support

**Do Not Merge:** requires Cfn update and should be tested on CODE

Adds CORS support with configurable domain whitelist. I recommend [viewing the diff with whitespace ignored](https://github.com/guardian/consent-logs/pull/25/files?w), lots of stuff got indented.

### CORS support in the source code

Adds CORS headers to the responses, as well as origin checks to the handler. The origin checks are informed by a new piece of configuration, drawn from the CloudFormation (see below). We add support for checking the origin header against the configured whitelist. If it matches then the appropriate CORS headers are added to the response. If not, an HTTP 403 (forbidden) is returned.

The change is made up of three main parts:
* CORS whitelist obtained from ENV (via Cfn see below)
* CORS checks wired into handler and response helpers
* [cors module](src/cors.ts) that contains logic and helpers for the CORS functionality

The latter includes tests in `cors.test.spec`.

### Cloudformation

This supports configuring the CORS whitelist without adding dependencies to do complex configuration.

Also introduces the Cfn metadata block to neatly arrange and label the parameters. They're complicated enough now to benefit from some UX.
